### PR TITLE
Decouple receipts from payments

### DIFF
--- a/internal/app/member/model/member.go
+++ b/internal/app/member/model/member.go
@@ -66,6 +66,7 @@ type Member struct {
 	BusinessTypeName      string                   `json:"business_type_name"`
 	Specialty             string                   `json:"specialty"`
 	Education             string                   `json:"education"`
+	FixedPayment          bool                     `json:"fixed_payment"`
 }
 
 func NewFromRecord(
@@ -107,6 +108,7 @@ func NewFromRecord(
 		CompanyID:         rec.GetString("company_id"),
 		Specialty:         rec.GetString("specialty"),
 		Education:         rec.GetString("education"),
+		FixedPayment:      rec.GetInt("fixed_monthly_amount_in_euros") != 0,
 	}
 
 	member.setEmploymentStatus(rec)

--- a/internal/app/member/query/search_params.go
+++ b/internal/app/member/query/search_params.go
@@ -15,21 +15,22 @@ const DefaultListCount = int64(200)
 
 //nolint:tagliatelle
 type SearchParams struct {
-	Query           string   `json:"q"`
-	MemberNo        string   `json:"member_no"`
-	Name            string   `json:"name"`
-	Mobile          string   `json:"mobile"`
-	Phone           string   `json:"phone"`
-	Email           string   `json:"email"`
-	ActiveOnly      bool     `json:"active_only"`
-	CompanyID       string   `json:"company_id"`
-	LegacyArea      string   `json:"legacy_area"`
-	AddressCityIDs  []string `json:"address_city_ids"`
-	BusinessTypeIDs []string `json:"business_type_ids"`
-	WithComments    bool     `json:"with_comments"`
-	ChapterID       string   `json:"chapter_id"`
-	Columns         []string `json:"columns"`
-	Limit           int64    `json:"limit"`
+	Query                   string   `json:"q"`
+	MemberNo                string   `json:"member_no"`
+	Name                    string   `json:"name"`
+	Mobile                  string   `json:"mobile"`
+	Phone                   string   `json:"phone"`
+	Email                   string   `json:"email"`
+	ActiveOnly              bool     `json:"active_only"`
+	CompanyID               string   `json:"company_id"`
+	LegacyArea              string   `json:"legacy_area"`
+	AddressCityIDs          []string `json:"address_city_ids"`
+	BusinessTypeIDs         []string `json:"business_type_ids"`
+	WithComments            bool     `json:"with_comments"`
+	ChapterID               string   `json:"chapter_id"`
+	Columns                 []string `json:"columns"`
+	Limit                   int64    `json:"limit"`
+	WithFixedMonthlyPayment bool     `json:"with_fixed_monthly_payment"`
 }
 
 func (p *SearchParams) CompanyIDs() []string {
@@ -60,20 +61,21 @@ func NewSearchParams(values url.Values) *SearchParams {
 	}
 
 	return &SearchParams{
-		Query:           values.Get("q"),
-		MemberNo:        values.Get("member_no"),
-		Name:            values.Get("name"),
-		Mobile:          values.Get("mobile"),
-		Phone:           values.Get("phone"),
-		Email:           values.Get("email"),
-		ActiveOnly:      values.Get("active_only") != "false",
-		CompanyID:       values.Get("company_id"),
-		LegacyArea:      values.Get("legacy_area"),
-		AddressCityIDs:  values["address_city_ids"],
-		BusinessTypeIDs: values["business_type_ids"],
-		WithComments:    values.Get("with_comments") == "true",
-		ChapterID:       values.Get("chapter_id"),
-		Limit:           int64(limit),
+		Query:                   values.Get("q"),
+		MemberNo:                values.Get("member_no"),
+		Name:                    values.Get("name"),
+		Mobile:                  values.Get("mobile"),
+		Phone:                   values.Get("phone"),
+		Email:                   values.Get("email"),
+		ActiveOnly:              values.Get("active_only") != "false",
+		CompanyID:               values.Get("company_id"),
+		LegacyArea:              values.Get("legacy_area"),
+		AddressCityIDs:          values["address_city_ids"],
+		BusinessTypeIDs:         values["business_type_ids"],
+		WithComments:            values.Get("with_comments") == "true",
+		ChapterID:               values.Get("chapter_id"),
+		WithFixedMonthlyPayment: values.Get("with_fixed_monthly_payment") == "true",
+		Limit:                   int64(limit),
 	}
 }
 
@@ -184,6 +186,10 @@ func (p *SearchParams) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 		}
 
 		expr = dbx.And(expr, dbx.Or(addressExpr...))
+	}
+
+	if p.WithFixedMonthlyPayment {
+		expr = dbx.And(expr, dbx.NewExp("members.fixed_monthly_amount_in_euros > 0"))
 	}
 
 	return query.Distinct(true).Where(expr)

--- a/internal/app/member/service/update_member_request.go
+++ b/internal/app/member/service/update_member_request.go
@@ -10,6 +10,10 @@ import (
 	"github.com/fragoulis/setip_v2/internal/utils"
 )
 
+const (
+	subscriptionFee = 2
+)
+
 type UpdateMemberRequest struct {
 	FirstName         string `json:"first_name"`
 	LastName          string `json:"last_name"`
@@ -28,6 +32,7 @@ type UpdateMemberRequest struct {
 	AddressStreetNo   string `json:"address_street_no"`
 	CompanyID         string `json:"company_id"`
 	Specialty         string `json:"specialty"`
+	FixedPayment      bool   `json:"fixed_payment"`
 
 	// Support unstructured addresses for the rare occussions
 	// someone lives outside of Attica.
@@ -54,29 +59,35 @@ func (r *UpdateMemberRequest) ToFormData(dao *daos.Dao) (map[string]any, error) 
 		r.AddressCityID = addressStreet.GetString("city_id")
 	}
 
+	fixedMonthlyAmount := 0
+	if r.FixedPayment {
+		fixedMonthlyAmount = subscriptionFee
+	}
+
 	return map[string]any{
-		"first_name":          firstName,
-		"last_name":           lastName,
-		"full_name":           fullName,
-		"father_name":         utils.Normalize(r.FatherName),
-		"email":               utils.Normalize(r.Email),
-		"mobile":              r.Mobile,
-		"phone":               r.Phone,
-		"birthdate":           r.Birthdate,
-		"id_card_number":      utils.Normalize(r.IDCardNumber),
-		"social_security_num": utils.Normalize(r.SocialSecurityNum),
-		"other_union":         r.OtherUnion,
-		"education":           utils.Normalize(r.Education),
-		"comments":            strconv.Quote(r.Comments),
-		"company_id":          r.CompanyID,
-		"specialty":           utils.Normalize(r.Specialty),
-		"address_city_id":     r.AddressCityID,
-		"address_street_id":   r.AddressStreetID,
-		"address_street_no":   r.AddressStreetNo,
-		"legacy_address":      utils.Normalize(r.LegacyAddress),
-		"legacy_area":         utils.Normalize(r.LegacyArea),
-		"legacy_city":         utils.Normalize(r.LegacyCity),
-		"legacy_post_code":    utils.Normalize(r.LegacyPostCode),
+		"first_name":                    firstName,
+		"last_name":                     lastName,
+		"full_name":                     fullName,
+		"father_name":                   utils.Normalize(r.FatherName),
+		"email":                         utils.Normalize(r.Email),
+		"mobile":                        r.Mobile,
+		"phone":                         r.Phone,
+		"birthdate":                     r.Birthdate,
+		"id_card_number":                utils.Normalize(r.IDCardNumber),
+		"social_security_num":           utils.Normalize(r.SocialSecurityNum),
+		"other_union":                   r.OtherUnion,
+		"education":                     utils.Normalize(r.Education),
+		"comments":                      strconv.Quote(r.Comments),
+		"company_id":                    r.CompanyID,
+		"specialty":                     utils.Normalize(r.Specialty),
+		"address_city_id":               r.AddressCityID,
+		"address_street_id":             r.AddressStreetID,
+		"address_street_no":             r.AddressStreetNo,
+		"legacy_address":                utils.Normalize(r.LegacyAddress),
+		"legacy_area":                   utils.Normalize(r.LegacyArea),
+		"legacy_city":                   utils.Normalize(r.LegacyCity),
+		"legacy_post_code":              utils.Normalize(r.LegacyPostCode),
+		"fixed_monthly_amount_in_euros": fixedMonthlyAmount,
 	}, nil
 }
 

--- a/internal/app/payment/api/routes.go
+++ b/internal/app/payment/api/routes.go
@@ -12,5 +12,6 @@ func RegisterRoutes(e *core.ServeEvent, app *pocketbase.PocketBase) {
 	e.Router.GET("/payments", http.List(app), apis.RequireAdminOrRecordAuth("users"))
 	e.Router.GET("/payments/:id", http.Get(app), apis.RequireAdminOrRecordAuth("users"))
 	e.Router.POST("/payments", http.Create(app), apis.RequireAdminOrRecordAuth("users"))
+	e.Router.POST("/payments/batch", http.CreateBatch(app), apis.RequireAdminOrRecordAuth("users"))
 	e.Router.PATCH("/payments", http.Update(app), apis.RequireAdminOrRecordAuth("users"))
 }

--- a/internal/app/payment/api/routes.go
+++ b/internal/app/payment/api/routes.go
@@ -10,6 +10,7 @@ import (
 
 func RegisterRoutes(e *core.ServeEvent, app *pocketbase.PocketBase) {
 	e.Router.GET("/payments", http.List(app), apis.RequireAdminOrRecordAuth("users"))
+	e.Router.GET("/payments/:id", http.Get(app), apis.RequireAdminOrRecordAuth("users"))
 	e.Router.POST("/payments", http.Create(app), apis.RequireAdminOrRecordAuth("users"))
 	e.Router.PATCH("/payments", http.Update(app), apis.RequireAdminOrRecordAuth("users"))
 }

--- a/internal/app/payment/http/handlers.go
+++ b/internal/app/payment/http/handlers.go
@@ -76,6 +76,26 @@ func Create(app *pocketbase.PocketBase) func(echo.Context) error {
 	}
 }
 
+func CreateBatch(app *pocketbase.PocketBase) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		ctx.Set("dao", app.Dao())
+
+		data := &service.CreateBatchPaymentRequest{}
+
+		err := rest.CopyJsonBody(ctx.Request(), &data)
+		if err != nil {
+			return apis.NewBadRequestError("failed to copy data", err)
+		}
+
+		model, err := service.CreateBatch(ctx, app, data)
+		if err != nil {
+			return apis.NewBadRequestError("failed to create batch payments", err)
+		}
+
+		return ctx.JSON(http.StatusCreated, model)
+	}
+}
+
 func Update(app *pocketbase.PocketBase) func(echo.Context) error {
 	return func(ctx echo.Context) error {
 		ctx.Set("dao", app.Dao())

--- a/internal/app/payment/model/payment.go
+++ b/internal/app/payment/model/payment.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/labstack/echo/v5"
@@ -47,12 +48,25 @@ func NewFromRecord(rec *models.Record) *Payment {
 func NewFromRecordNoMember(rec *models.Record, memberNo, memberName string) *Payment {
 	receipt := rec.ExpandedOne("receipt_id")
 
-	receiptBlockNo := 0
-	receiptNo := 0
+	receiptBlockNo := -1
+	receiptNo := -1
 
 	if receipt != nil {
-		receiptBlockNo = receipt.GetInt("block_no")
-		receiptNo = receipt.GetInt("receipt_no")
+		var err error
+
+		if receipt.GetString("block_no") != "" {
+			receiptBlockNo, err = strconv.Atoi(receipt.GetString("block_no"))
+			if err != nil {
+				panic(fmt.Errorf("failed to covert block no to int: %w", err))
+			}
+		}
+
+		if receipt.GetString("receipt_no") != "" {
+			receiptNo, err = strconv.Atoi(receipt.GetString("receipt_no"))
+			if err != nil {
+				panic(fmt.Errorf("failed to covert receipt no to int: %w", err))
+			}
+		}
 	}
 
 	return &Payment{

--- a/internal/app/payment/query/search.go
+++ b/internal/app/payment/query/search.go
@@ -2,82 +2,30 @@ package query
 
 import (
 	"fmt"
-	"net/url"
-	"strconv"
 
 	"github.com/labstack/echo/v5"
-	"github.com/pocketbase/dbx"
-	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/daos"
 	"github.com/pocketbase/pocketbase/models"
-	"github.com/pocketbase/pocketbase/tools/list"
 
+	"github.com/fragoulis/setip_v2/internal/app/errors"
 	"github.com/fragoulis/setip_v2/internal/app/payment/model"
 )
 
-const (
-	DefaultListCount = int64(50)
-)
-
-//nolint:tagliatelle
-type ListPaymentsRequest struct {
-	ID        string   `json:"id"`
-	MemberIDs []string `json:"member_ids"`
-	UserIDs   []string `json:"user_ids"`
-	Limit     int64    `json:"limit"`
-}
-
-func NewListPaymentsRequest(values url.Values) *ListPaymentsRequest {
-	limit := 0
-
-	limitRaw := values.Get("limit")
-	if limitRaw != "" {
-		limit, _ = strconv.Atoi(limitRaw)
-	}
-
-	return &ListPaymentsRequest{
-		ID:        values.Get("id"),
-		UserIDs:   values["user_ids"],
-		MemberIDs: values["member_ids"],
-		Limit:     int64(limit),
-	}
-}
-
-func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
-	if p.ID != "" {
-		return query.Where(&dbx.HashExp{"id": p.ID}).Limit(1)
-	}
-
-	limit := DefaultListCount
-	if p.Limit > 0 {
-		limit = p.Limit
-	}
-
-	expr := dbx.NewExp("")
-
-	if len(p.UserIDs) > 0 {
-		expr = dbx.And(dbx.In("created_by_user_id", list.ToInterfaceSlice(p.UserIDs)...))
-	}
-
-	if len(p.MemberIDs) > 0 {
-		expr = dbx.And(dbx.In("member_id", list.ToInterfaceSlice(p.MemberIDs)...))
-	}
-
-	return query.Where(expr).Limit(limit)
-}
-
 func List(
 	ctx echo.Context,
-	app *pocketbase.PocketBase,
 	params *ListPaymentsRequest,
 ) ([]*model.Payment, error) {
-	dao := app.Dao()
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return nil, errors.ErrFailedToGetDao
+	}
 
 	query := params.Apply(dao.RecordQuery("payments"))
 
 	records := []*models.Record{}
 
-	err := query.OrderBy("issued_at DESC").All(&records)
+	err := query.All(&records)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -87,6 +35,7 @@ func List(
 		dao,
 		records,
 		"member_id",
+		"receipt_id",
 		"created_by_user_id",
 	)
 	if err != nil {
@@ -99,4 +48,50 @@ func List(
 	}
 
 	return payments, nil
+}
+
+func Count(ctx echo.Context, params *ListPaymentsRequest) (int, error) {
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return 0, errors.ErrFailedToGetDao
+	}
+
+	query := params.Apply(dao.RecordQuery("payments"))
+
+	var count int
+
+	err := query.
+		Select("count(distinct payments.id)").
+		Limit(1).Row(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	return count, nil
+}
+
+func FindByID(ctx echo.Context, id string) (*model.Payment, error) {
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return nil, errors.ErrFailedToGetDao
+	}
+
+	record, err := dao.FindRecordById("payments", id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	err = apis.EnrichRecord(
+		ctx,
+		dao,
+		record,
+		"member_id",
+		"receipt_id",
+		"created_by_user_id",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand relations for payment: %w", err)
+	}
+
+	return model.NewFromRecord(record), nil
 }

--- a/internal/app/payment/query/search_params.go
+++ b/internal/app/payment/query/search_params.go
@@ -1,0 +1,123 @@
+package query
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/tools/list"
+
+	"github.com/fragoulis/setip_v2/internal/utils"
+)
+
+const (
+	DefaultListCount = int64(50)
+)
+
+//nolint:tagliatelle
+type ListPaymentsRequest struct {
+	Query        string   `json:"q"`
+	PaymentIDs   []string `json:"member_ids"`
+	UserIDs      []string `json:"user_ids"`
+	WithReceipts *bool    `json:"with_receipts"`
+	Page         int64    `json:"page"`
+	PerPage      int64    `json:"per_page"`
+	Sort         string   `json:"sort"`
+}
+
+func NewListPaymentsRequest(values url.Values) *ListPaymentsRequest {
+	page := 0
+	perPage := 0
+
+	var withReceipts *bool
+
+	pageRaw := values.Get("page")
+	if pageRaw != "" {
+		page, _ = strconv.Atoi(pageRaw)
+	}
+
+	perPageRaw := values.Get("per_page")
+	if perPageRaw != "" {
+		perPage, _ = strconv.Atoi(perPageRaw)
+	}
+
+	withReceiptsRaw := values.Get("with_receipts")
+	if withReceiptsRaw != "" {
+		value, err := strconv.ParseBool(withReceiptsRaw)
+		if err == nil {
+			withReceipts = &value
+		}
+	}
+
+	return &ListPaymentsRequest{
+		Query:        values.Get("q"),
+		UserIDs:      values["user_ids"],
+		PaymentIDs:   values["member_ids"],
+		WithReceipts: withReceipts,
+		Page:         int64(page),
+		PerPage:      int64(perPage),
+		Sort:         values.Get("sort"),
+	}
+}
+
+func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
+	perPage := DefaultListCount
+	if p.PerPage > 0 && p.PerPage < 500 {
+		perPage = p.PerPage
+	}
+
+	page := int64(1)
+	if p.Page > 0 {
+		page = p.Page
+	}
+
+	sort := "issued_at desc"
+	if p.Sort != "" {
+		sort = p.Sort
+	}
+
+	expr := dbx.NewExp("")
+
+	if len(p.UserIDs) > 0 {
+		expr = dbx.And(dbx.In("created_by_user_id", list.ToInterfaceSlice(p.UserIDs)...))
+	}
+
+	if len(p.PaymentIDs) > 0 {
+		expr = dbx.And(dbx.In("member_id", list.ToInterfaceSlice(p.PaymentIDs)...))
+	}
+
+	if p.WithReceipts != nil {
+		if *p.WithReceipts {
+			expr = dbx.And(dbx.NewExp("receipt_id is not null"))
+		} else {
+			expr = dbx.And(dbx.NewExp("receipt_id is null"))
+		}
+	}
+
+	if p.Query != "" {
+		query = query.InnerJoin(
+			"members",
+			dbx.NewExp("payments.member_id = members.id"),
+		)
+
+		searchQuery := utils.Normalize(p.Query)
+
+		queryExpr := dbx.Or(
+			dbx.Like("issued_at", searchQuery),
+			dbx.Like("concat(members.first_name, ' ', members.last_name)", searchQuery),
+			dbx.Like("concat(members.last_name, ' ', members.first_name)", searchQuery),
+			dbx.Like("members.mobile", searchQuery),
+			dbx.Like("members.phone", searchQuery),
+			dbx.Like("members.email", searchQuery),
+			dbx.HashExp{"members.member_no": searchQuery},
+		)
+
+		expr = dbx.And(expr, queryExpr)
+	}
+
+	return query.
+		Where(expr).
+		OrderBy(sort).
+		Limit(perPage).
+		Offset((page - 1) * perPage)
+}

--- a/internal/app/payment/query/search_params.go
+++ b/internal/app/payment/query/search_params.go
@@ -82,9 +82,9 @@ func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 
 	if p.ReceiptState != "" {
 		if p.ReceiptState == "with" {
-			expr = dbx.And(expr, dbx.NewExp("receipt_id is not null"))
+			expr = dbx.And(expr, dbx.NewExp("receipt_id is not null and receipt_id != ''"))
 		} else {
-			expr = dbx.And(expr, dbx.NewExp("receipt_id is null"))
+			expr = dbx.And(expr, dbx.NewExp("receipt_id is null or receipt_id = ''"))
 		}
 	}
 

--- a/internal/app/payment/query/search_params.go
+++ b/internal/app/payment/query/search_params.go
@@ -89,11 +89,11 @@ func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 	}
 
 	if p.IssueDateFrom != "" {
-		expr = dbx.And(expr, dbx.NewExp("issued_at >= {:from}", dbx.Params{"from": p.IssueDateFrom}))
+		expr = dbx.And(expr, dbx.NewExp("date(issued_at) >= {:from}", dbx.Params{"from": p.IssueDateFrom}))
 	}
 
 	if p.IssueDateTo != "" {
-		expr = dbx.And(expr, dbx.NewExp("issued_at <= {:to}", dbx.Params{"to": p.IssueDateTo}))
+		expr = dbx.And(expr, dbx.NewExp("date(issued_at) <= {:to}", dbx.Params{"to": p.IssueDateTo}))
 	}
 
 	if p.Query != "" {

--- a/internal/app/payment/query/search_params.go
+++ b/internal/app/payment/query/search_params.go
@@ -16,20 +16,20 @@ const (
 
 //nolint:tagliatelle
 type ListPaymentsRequest struct {
-	Query        string   `json:"q"`
-	PaymentIDs   []string `json:"member_ids"`
-	UserIDs      []string `json:"user_ids"`
-	WithReceipts *bool    `json:"with_receipts"`
-	Page         int64    `json:"page"`
-	PerPage      int64    `json:"per_page"`
-	Sort         string   `json:"sort"`
+	Query         string   `json:"q"`
+	PaymentIDs    []string `json:"member_ids"`
+	UserIDs       []string `json:"user_ids"`
+	ReceiptState  string   `json:"receipt_state"`
+	IssueDateFrom string   `json:"issue_date_from"`
+	IssueDateTo   string   `json:"issue_date_to"`
+	Page          int64    `json:"page"`
+	PerPage       int64    `json:"per_page"`
+	Sort          string   `json:"sort"`
 }
 
 func NewListPaymentsRequest(values url.Values) *ListPaymentsRequest {
 	page := 0
 	perPage := 0
-
-	var withReceipts *bool
 
 	pageRaw := values.Get("page")
 	if pageRaw != "" {
@@ -41,22 +41,16 @@ func NewListPaymentsRequest(values url.Values) *ListPaymentsRequest {
 		perPage, _ = strconv.Atoi(perPageRaw)
 	}
 
-	withReceiptsRaw := values.Get("with_receipts")
-	if withReceiptsRaw != "" {
-		value, err := strconv.ParseBool(withReceiptsRaw)
-		if err == nil {
-			withReceipts = &value
-		}
-	}
-
 	return &ListPaymentsRequest{
-		Query:        values.Get("q"),
-		UserIDs:      values["user_ids"],
-		PaymentIDs:   values["member_ids"],
-		WithReceipts: withReceipts,
-		Page:         int64(page),
-		PerPage:      int64(perPage),
-		Sort:         values.Get("sort"),
+		Query:         values.Get("q"),
+		UserIDs:       values["user_ids"],
+		PaymentIDs:    values["member_ids"],
+		ReceiptState:  values.Get("receipt_state"),
+		IssueDateFrom: values.Get("issue_date_from"),
+		IssueDateTo:   values.Get("issue_date_to"),
+		Page:          int64(page),
+		PerPage:       int64(perPage),
+		Sort:          values.Get("sort"),
 	}
 }
 
@@ -86,12 +80,20 @@ func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 		expr = dbx.And(dbx.In("member_id", list.ToInterfaceSlice(p.PaymentIDs)...))
 	}
 
-	if p.WithReceipts != nil {
-		if *p.WithReceipts {
+	if p.ReceiptState != "" {
+		if p.ReceiptState == "with" {
 			expr = dbx.And(dbx.NewExp("receipt_id is not null"))
 		} else {
 			expr = dbx.And(dbx.NewExp("receipt_id is null"))
 		}
+	}
+
+	if p.IssueDateFrom != "" {
+		expr = dbx.And(dbx.NewExp("issued_at >= {:from}", dbx.Params{"from": p.IssueDateFrom}))
+	}
+
+	if p.IssueDateTo != "" {
+		expr = dbx.And(dbx.NewExp("issued_at <= {:to}", dbx.Params{"to": p.IssueDateTo}))
 	}
 
 	if p.Query != "" {
@@ -103,7 +105,6 @@ func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 		searchQuery := utils.Normalize(p.Query)
 
 		queryExpr := dbx.Or(
-			dbx.Like("issued_at", searchQuery),
 			dbx.Like("concat(members.first_name, ' ', members.last_name)", searchQuery),
 			dbx.Like("concat(members.last_name, ' ', members.first_name)", searchQuery),
 			dbx.Like("members.mobile", searchQuery),

--- a/internal/app/payment/query/search_params.go
+++ b/internal/app/payment/query/search_params.go
@@ -73,27 +73,27 @@ func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 	expr := dbx.NewExp("")
 
 	if len(p.UserIDs) > 0 {
-		expr = dbx.And(dbx.In("created_by_user_id", list.ToInterfaceSlice(p.UserIDs)...))
+		expr = dbx.And(expr, dbx.In("created_by_user_id", list.ToInterfaceSlice(p.UserIDs)...))
 	}
 
 	if len(p.PaymentIDs) > 0 {
-		expr = dbx.And(dbx.In("member_id", list.ToInterfaceSlice(p.PaymentIDs)...))
+		expr = dbx.And(expr, dbx.In("member_id", list.ToInterfaceSlice(p.PaymentIDs)...))
 	}
 
 	if p.ReceiptState != "" {
 		if p.ReceiptState == "with" {
-			expr = dbx.And(dbx.NewExp("receipt_id is not null"))
+			expr = dbx.And(expr, dbx.NewExp("receipt_id is not null"))
 		} else {
-			expr = dbx.And(dbx.NewExp("receipt_id is null"))
+			expr = dbx.And(expr, dbx.NewExp("receipt_id is null"))
 		}
 	}
 
 	if p.IssueDateFrom != "" {
-		expr = dbx.And(dbx.NewExp("issued_at >= {:from}", dbx.Params{"from": p.IssueDateFrom}))
+		expr = dbx.And(expr, dbx.NewExp("issued_at >= {:from}", dbx.Params{"from": p.IssueDateFrom}))
 	}
 
 	if p.IssueDateTo != "" {
-		expr = dbx.And(dbx.NewExp("issued_at <= {:to}", dbx.Params{"to": p.IssueDateTo}))
+		expr = dbx.And(expr, dbx.NewExp("issued_at <= {:to}", dbx.Params{"to": p.IssueDateTo}))
 	}
 
 	if p.Query != "" {
@@ -104,16 +104,14 @@ func (p *ListPaymentsRequest) Apply(query *dbx.SelectQuery) *dbx.SelectQuery {
 
 		searchQuery := utils.Normalize(p.Query)
 
-		queryExpr := dbx.Or(
+		expr = dbx.And(expr, dbx.Or(
 			dbx.Like("concat(members.first_name, ' ', members.last_name)", searchQuery),
 			dbx.Like("concat(members.last_name, ' ', members.first_name)", searchQuery),
 			dbx.Like("members.mobile", searchQuery),
 			dbx.Like("members.phone", searchQuery),
 			dbx.Like("members.email", searchQuery),
 			dbx.HashExp{"members.member_no": searchQuery},
-		)
-
-		expr = dbx.And(expr, queryExpr)
+		))
 	}
 
 	return query.

--- a/internal/app/payment/service/create.go
+++ b/internal/app/payment/service/create.go
@@ -39,6 +39,12 @@ var requiredReceiptBlockNo = validation.NewError(
 	"Το πεδίο πρέπει να συμπληρωθεί αφού υπάρχει αριθμός απόδειξης.",
 )
 
+//nolint:gochecknoglobals
+var cannotEditPayment = validation.NewError(
+	"validation_required",
+	"Η είσπραξη ή/και η απόδειξη δε μπορούν να τροποποιηθούν γιατί η απόδειξη είναι κοινή για παραπάνω από μία εισπράξεις.",
+)
+
 //
 //nolint:gochecknoglobals
 var invalidAmount = validation.NewError(
@@ -58,6 +64,7 @@ type CreatePaymentRequest struct {
 	ReceiptNo               int    `json:"receipt_no"`
 	IssuedAt                string `json:"issued_at"`
 	Comments                string `json:"comments"`
+	WithoutReceipt          bool   `json:"without_receipt"`
 }
 
 type CreatePaymentResponse struct {
@@ -93,7 +100,7 @@ func Create(
 			errs["amount"] = insufficientAmount
 		}
 
-		if data.ReceiptNo > 0 && data.ReceiptBlockNo <= 0 {
+		if !data.WithoutReceipt && data.ReceiptNo > 0 && data.ReceiptBlockNo <= 0 {
 			errs["receipt_block_no"] = requiredReceiptBlockNo
 		}
 	}
@@ -117,12 +124,17 @@ func Create(
 		data.Months = int(math.Floor(float64(data.Amount) / float64(subscriptionFee)))
 	}
 
-	collection, err := app.Dao().FindCollectionByNameOrId("payments")
+	paymentsCollection, err := app.Dao().FindCollectionByNameOrId("payments")
 	if err != nil {
-		return nil, fmt.Errorf("failed to find collection: %w", err)
+		return nil, fmt.Errorf("failed to find payments collection: %w", err)
 	}
 
-	newPayment := models.NewRecord(collection)
+	newPayment := models.NewRecord(paymentsCollection)
+
+	receiptsCollection, err := app.Dao().FindCollectionByNameOrId("receipts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find receipts collection: %w", err)
+	}
 
 	member, err := query.FindByID(ctx, data.MemberID)
 	if err != nil {
@@ -171,10 +183,46 @@ Unknown error: %s`, err)
 	err = dao.RunInTransaction(func(tx *daos.Dao) error {
 		ctx.Set("dao", tx)
 
+		newReceipt := models.NewRecord(receiptsCollection)
+
+		if !data.WithoutReceipt {
+			form := forms.NewRecordUpsert(app, newReceipt)
+			form.SetDao(tx)
+
+			newReceiptData := map[string]any{
+				"member_id":          data.MemberID,
+				"amount_in_euros":    data.Amount,
+				"issued_at":          issuedAt,
+				"comments":           data.Comments,
+				"created_by_user_id": utils.CurrentUserID(ctx),
+			}
+
+			if data.ReceiptNo > 0 {
+				newReceiptData["receipt_no"] = data.ReceiptNo
+			}
+
+			if data.ReceiptBlockNo > 0 {
+				newReceiptData["block_no"] = data.ReceiptBlockNo
+			}
+
+			err := form.LoadData(newReceiptData)
+			if err != nil {
+				return fmt.Errorf("failed to load receipt data: %w", err)
+			}
+
+			err = events.WrapCreate(ctx, app, newPayment, func() error {
+				return form.Submit()
+			})
+			if err != nil {
+				//nolint:wrapcheck
+				return err
+			}
+		}
+
 		form := forms.NewRecordUpsert(app, newPayment)
 		form.SetDao(tx)
 
-		newData := map[string]any{
+		newPaymentData := map[string]any{
 			"member_id":                 data.MemberID,
 			"amount_in_euros":           data.Amount,
 			"months":                    data.Months,
@@ -182,23 +230,16 @@ Unknown error: %s`, err)
 			"issued_at":                 issuedAt,
 			"comments":                  data.Comments,
 			"created_by_user_id":        utils.CurrentUserID(ctx),
+			"receipt_id":                newReceipt.GetId(),
 		}
 
 		if !memberHasPaidUntil.IsZero() {
-			newData["legacy_to"] = utils.EndOfMonthAhead(memberHasPaidUntil, data.Months)
+			newPaymentData["legacy_to"] = utils.EndOfMonthAhead(memberHasPaidUntil, data.Months)
 		}
 
-		if data.ReceiptNo > 0 {
-			newData["receipt_no"] = data.ReceiptNo
-		}
-
-		if data.ReceiptBlockNo > 0 {
-			newData["receipt_block_no"] = data.ReceiptBlockNo
-		}
-
-		err := form.LoadData(newData)
+		err := form.LoadData(newPaymentData)
 		if err != nil {
-			return fmt.Errorf("failed to load data: %w", err)
+			return fmt.Errorf("failed to load payment data: %w", err)
 		}
 
 		err = events.WrapCreate(ctx, app, newPayment, func() error {

--- a/internal/app/payment/service/create.go
+++ b/internal/app/payment/service/create.go
@@ -250,11 +250,6 @@ Unknown error: %s`, err)
 			return err
 		}
 
-		member, err = query.FindByID(ctx, data.MemberID)
-		if err != nil {
-			return fmt.Errorf("failed to find member: %w", err)
-		}
-
 		return nil
 	})
 	if err != nil {

--- a/internal/app/payment/service/create.go
+++ b/internal/app/payment/service/create.go
@@ -10,6 +10,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/daos"
 	"github.com/pocketbase/pocketbase/forms"
 	"github.com/pocketbase/pocketbase/models"
@@ -34,9 +35,9 @@ var memberNotFoundErr = validation.NewError("validation_required", "Δεν υπ�
 var insufficientAmount = validation.NewError("validation_required", "Το ποσό δεν επαρκεί αφού περιέχει εγγραφή")
 
 //nolint:gochecknoglobals
-var requiredReceiptBlockNo = validation.NewError(
+var requiredField = validation.NewError(
 	"validation_required",
-	"Το πεδίο πρέπει να συμπληρωθεί αφού υπάρχει αριθμός απόδειξης.",
+	"Το πεδίο πρέπει να συμπληρωθεί.",
 )
 
 //nolint:gochecknoglobals
@@ -100,8 +101,12 @@ func Create(
 			errs["amount"] = insufficientAmount
 		}
 
-		if !data.WithoutReceipt && data.ReceiptNo > 0 && data.ReceiptBlockNo <= 0 {
-			errs["receipt_block_no"] = requiredReceiptBlockNo
+		if !data.WithoutReceipt && data.ReceiptNo <= 0 {
+			errs["receipt_no"] = requiredField
+		}
+
+		if !data.WithoutReceipt && data.ReceiptBlockNo <= 0 {
+			errs["receipt_block_no"] = requiredField
 		}
 	}
 
@@ -256,8 +261,24 @@ Unknown error: %s`, err)
 		return nil, err
 	}
 
+	// Fetch newly created record
+	newRec, err := dao.FindRecordById("payments", newPayment.GetId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to find new record: %w", err)
+	}
+
+	err = apis.EnrichRecord(
+		ctx,
+		dao,
+		newRec,
+		"receipt_id",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand relations for companies: %w", err)
+	}
+
 	return &CreatePaymentResponse{
-		Payment: model.NewFromRecordNoMember(newPayment, member.MemberNo, member.FullName),
+		Payment: model.NewFromRecordNoMember(newRec, member.MemberNo, member.FullName),
 		Status:  member.PaymentStatus.Formatted,
 	}, nil
 }

--- a/internal/app/payment/service/create_batch.go
+++ b/internal/app/payment/service/create_batch.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/daos"
+	"github.com/pocketbase/pocketbase/forms"
+	"github.com/pocketbase/pocketbase/models"
+
+	internalErrors "github.com/fragoulis/setip_v2/internal/app/errors"
+	memberModel "github.com/fragoulis/setip_v2/internal/app/member/model"
+	"github.com/fragoulis/setip_v2/internal/app/member/query"
+	"github.com/fragoulis/setip_v2/internal/app/payment/model"
+	"github.com/fragoulis/setip_v2/internal/events"
+	"github.com/fragoulis/setip_v2/internal/utils"
+)
+
+type CreateBatchPaymentRequest struct {
+	//nolint:tagliatelle
+	MemberIDs []string `json:"member_ids"`
+	Amount    int      `json:"amount"`
+	IssuedAt  string   `json:"issued_at"`
+	Comments  string   `json:"comments"`
+}
+
+type CreateBatchPaymentResponse struct {
+	Payments []*model.Payment
+}
+
+//nolint:funlen,gocognit,cyclop
+func CreateBatch(
+	ctx echo.Context,
+	app *pocketbase.PocketBase,
+	data *CreateBatchPaymentRequest,
+) (*CreateBatchPaymentResponse, error) {
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return nil, internalErrors.ErrFailedToGetDao
+	}
+
+	errs := validation.Errors{}
+
+	for _, memberID := range data.MemberIDs {
+		// Make sure that members exist.
+		_, err := dao.FindRecordById("members", memberID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				errs["amount"] = memberNotFoundErr
+
+				break
+			}
+		}
+	}
+
+	if data.Amount <= 0 {
+		errs["amount"] = invalidAmount
+	}
+
+	if len(errs) != 0 {
+		return nil, errs
+	}
+
+	paymentsCollection, err := app.Dao().FindCollectionByNameOrId("payments")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find payments collection: %w", err)
+	}
+
+	newPayments := []*model.Payment{}
+
+	for _, memberID := range data.MemberIDs {
+		err = dao.RunInTransaction(func(tx *daos.Dao) error {
+			ctx.Set("dao", tx)
+
+			member, err := query.FindByID(ctx, memberID)
+			if err != nil {
+				return fmt.Errorf("failed to find member: %w", err)
+			}
+
+			// Temporary: set the legacy_to field which is needed to calculate
+			// until which date a member has paid for.
+			memberHasPaidUntil, err := member.MemberHasPaidUntil()
+			if err != nil {
+				if errors.Is(err, memberModel.ErrUnableToDeterminePaymentStatus) {
+					data.Comments += `
+SYSTEM: Payment created without a legacy_to because the member had no active subscription.
+`
+				} else {
+					data.Comments += fmt.Sprintf(`
+Unknown error: %s`, err)
+				}
+			}
+
+			newPayment := models.NewRecord(paymentsCollection)
+
+			// Add time to this date.
+			parsedIssuedAt, err := time.Parse(time.DateOnly, data.IssuedAt)
+			if err != nil {
+				return fmt.Errorf("failed to parse issue date: %w", err)
+			}
+
+			// Get the current time
+			currentTime := time.Now()
+
+			// Update the parsed time with the current hour, minute, and second
+			issuedAt := time.Date(
+				parsedIssuedAt.Year(),
+				parsedIssuedAt.Month(),
+				parsedIssuedAt.Day(),
+				currentTime.Hour(),
+				currentTime.Minute(),
+				currentTime.Second(),
+				currentTime.Nanosecond(),
+				parsedIssuedAt.Location(),
+			)
+
+			form := forms.NewRecordUpsert(app, newPayment)
+			form.SetDao(tx)
+
+			months := int(math.Floor(float64(data.Amount) / float64(subscriptionFee)))
+
+			newPaymentData := map[string]any{
+				"member_id":          memberID,
+				"amount_in_euros":    data.Amount,
+				"months":             months,
+				"issued_at":          issuedAt,
+				"comments":           data.Comments,
+				"created_by_user_id": utils.CurrentUserID(ctx),
+			}
+
+			if !memberHasPaidUntil.IsZero() {
+				newPaymentData["legacy_to"] = utils.EndOfMonthAhead(memberHasPaidUntil, months)
+			}
+
+			err = form.LoadData(newPaymentData)
+			if err != nil {
+				return fmt.Errorf("failed to load payment data: %w", err)
+			}
+
+			err = events.WrapCreate(ctx, app, newPayment, func() error {
+				return form.Submit()
+			})
+			if err != nil {
+				//nolint:wrapcheck
+				return err
+			}
+
+			newPayments = append(newPayments, model.NewFromRecordNoMember(newPayment, member.MemberNo, member.FullName))
+
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &CreateBatchPaymentResponse{
+		Payments: newPayments,
+	}, nil
+}

--- a/internal/app/payment/service/update.go
+++ b/internal/app/payment/service/update.go
@@ -82,8 +82,12 @@ func Update(
 		errs["amount"] = invalidAmount
 	}
 
-	if !data.WithoutReceipt && data.ReceiptNo > 0 && data.ReceiptBlockNo <= 0 {
-		errs["receipt_block_no"] = requiredReceiptBlockNo
+	if !data.WithoutReceipt && data.ReceiptNo <= 0 {
+		errs["receipt_no"] = requiredField
+	}
+
+	if !data.WithoutReceipt && data.ReceiptBlockNo <= 0 {
+		errs["receipt_block_no"] = requiredField
 	}
 
 	if len(errs) != 0 {

--- a/internal/app/receipt/api/routes.go
+++ b/internal/app/receipt/api/routes.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+
+	"github.com/fragoulis/setip_v2/internal/app/receipt/http"
+)
+
+func RegisterRoutes(e *core.ServeEvent, app *pocketbase.PocketBase) {
+	e.Router.POST("/receipts", http.Create(app), apis.RequireAdminOrRecordAuth("users"))
+	e.Router.POST("/receipts/batch", http.CreateBatch(app), apis.RequireAdminOrRecordAuth("users"))
+}

--- a/internal/app/receipt/http/handlers.go
+++ b/internal/app/receipt/http/handlers.go
@@ -1,0 +1,52 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/tools/rest"
+
+	"github.com/fragoulis/setip_v2/internal/app/receipt/service"
+)
+
+func Create(app *pocketbase.PocketBase) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		ctx.Set("dao", app.Dao())
+
+		data := &service.CreateReceiptRequest{}
+
+		err := rest.CopyJsonBody(ctx.Request(), &data)
+		if err != nil {
+			return apis.NewBadRequestError("failed to copy data", err)
+		}
+
+		model, err := service.Create(ctx, app, data)
+		if err != nil {
+			return apis.NewBadRequestError("failed to create receipt", err)
+		}
+
+		return ctx.JSON(http.StatusCreated, model)
+	}
+}
+
+func CreateBatch(app *pocketbase.PocketBase) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		ctx.Set("dao", app.Dao())
+
+		data := &service.CreateBatchReceiptRequest{}
+
+		err := rest.CopyJsonBody(ctx.Request(), &data)
+		if err != nil {
+			return apis.NewBadRequestError("failed to copy data", err)
+		}
+
+		model, err := service.CreateBatch(ctx, app, data)
+		if err != nil {
+			return apis.NewBadRequestError("failed to create receipts", err)
+		}
+
+		return ctx.JSON(http.StatusCreated, model)
+	}
+}

--- a/internal/app/receipt/model/receipt.go
+++ b/internal/app/receipt/model/receipt.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/daos"
+	"github.com/pocketbase/pocketbase/models"
+	"github.com/pocketbase/pocketbase/tools/list"
+
+	"github.com/fragoulis/setip_v2/internal/app/errors"
+	"github.com/fragoulis/setip_v2/internal/utils"
+)
+
+type Receipt struct {
+	ID                string    `json:"id"`
+	MemberID          string    `json:"member_id"`
+	MemberNo          string    `json:"member_no"`
+	MemberName        string    `json:"member_name"`
+	Amount            int       `json:"amount"`
+	BlockNo           int       `json:"block_no"`
+	ReceiptNo         int       `json:"receipt_no"`
+	CreatedByUserID   string    `json:"created_by_user_id"`
+	CreatedByUser     *User     `json:"created_by_user"`
+	IssuedAt          time.Time `json:"issued_at"`
+	IssuedAtFormatted string    `json:"issued_at_formatted"`
+	Comments          string    `json:"comments"`
+}
+
+func NewFromRecord(rec *models.Record) *Receipt {
+	member := rec.ExpandedOne("member_id")
+
+	return NewFromRecordNoMember(
+		rec,
+		fmt.Sprintf("%06d", member.GetInt("member_no")),
+		member.GetString("full_name"),
+	)
+}
+
+func NewFromRecordNoMember(rec *models.Record, memberNo, memberName string) *Receipt {
+	return &Receipt{
+		ID:                rec.GetId(),
+		MemberID:          rec.GetString("member_id"),
+		MemberNo:          memberNo,
+		MemberName:        memberName,
+		Amount:            rec.GetInt("amount_in_euros"),
+		BlockNo:           rec.GetInt("block_no"),
+		ReceiptNo:         rec.GetInt("receipt_no"),
+		CreatedByUserID:   rec.GetString("created_by_user_id"),
+		CreatedByUser:     newUserFromRecord(rec.ExpandedOne("created_by_user_id")),
+		IssuedAt:          rec.GetDateTime("issued_at").Time(),
+		IssuedAtFormatted: utils.Day(rec.GetDateTime("issued_at").Time()),
+		Comments:          rec.GetString("comments"),
+	}
+}
+
+func FindByMemberID(ctx echo.Context, memberIDs []string) ([]*Receipt, error) {
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return nil, errors.ErrFailedToGetDao
+	}
+
+	records := []*models.Record{}
+
+	err := dao.RecordQuery("receipts").
+		Where(dbx.In("member_id", list.ToInterfaceSlice(memberIDs)...)).
+		OrderBy("issued_at DESC").
+		All(&records)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	// Expand the records relations (aka load associations).
+	if ctx.Request() != nil {
+		err = apis.EnrichRecords(
+			ctx,
+			dao,
+			records,
+			"member_id",
+			"created_by_user_id",
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand relations for receipts: %w", err)
+		}
+	} else {
+		errs := dao.ExpandRecords(records, []string{"created_by_user_id"}, nil)
+		if len(errs) > 0 {
+			return nil, fmt.Errorf("failed to expand relations for receipts: %v", errs)
+		}
+	}
+
+	models := make([]*Receipt, 0, len(records))
+	for _, record := range records {
+		models = append(models, NewFromRecord(record))
+	}
+
+	return models, nil
+}

--- a/internal/app/receipt/model/user.go
+++ b/internal/app/receipt/model/user.go
@@ -1,0 +1,19 @@
+package model
+
+import "github.com/pocketbase/pocketbase/models"
+
+type User struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+func newUserFromRecord(rec *models.Record) *User {
+	if rec == nil {
+		return nil
+	}
+
+	return &User{
+		ID:       rec.GetId(),
+		Username: rec.GetString("username"),
+	}
+}

--- a/internal/app/receipt/service/create.go
+++ b/internal/app/receipt/service/create.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/daos"
+
+	internalErrors "github.com/fragoulis/setip_v2/internal/app/errors"
+)
+
+//nolint:gochecknoglobals
+var paymentNotFoundErr = validation.NewError("validation_required", "Δεν υπάρχει πληρωμή με αυτό το ID")
+
+//nolint:gochecknoglobals
+var requiredErr = validation.NewError(
+	"validation_required",
+	"Το πεδίο πρέπει να συμπληρωθεί.",
+)
+
+type CreateReceiptRequest struct {
+	PaymentID string `json:"payment_id"`
+	BlockNo   int    `json:"block_no"`
+	ReceiptNo int    `json:"receipt_no"`
+	IssuedAt  string `json:"issued_at"`
+	Comments  string `json:"comments"`
+}
+
+type CreateReceiptResponse struct {
+	ID string `json:"id"`
+}
+
+//nolint:funlen,gocognit,cyclop
+func Create(
+	ctx echo.Context,
+	app *pocketbase.PocketBase,
+	data *CreateReceiptRequest,
+) (*CreateReceiptResponse, error) {
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return nil, internalErrors.ErrFailedToGetDao
+	}
+
+	errs := validation.Errors{}
+
+	// Load the payment.
+	payment, err := dao.FindRecordById("payments", data.PaymentID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			errs["payment_id"] = paymentNotFoundErr
+		}
+	}
+
+	if data.ReceiptNo > 0 {
+		errs["receipt_no"] = requiredErr
+	}
+
+	if data.BlockNo > 0 {
+		errs["block_no"] = requiredErr
+	}
+
+	if data.IssuedAt != "" {
+		errs["issued_at"] = requiredErr
+	}
+
+	if len(errs) != 0 {
+		return nil, errs
+	}
+
+	id, err := CreateInternal(ctx, app, dao, payment, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create receipt internal: %w", err)
+	}
+
+	return &CreateReceiptResponse{
+		ID: id,
+	}, nil
+}

--- a/internal/app/receipt/service/create_batch.go
+++ b/internal/app/receipt/service/create_batch.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/daos"
+	"github.com/pocketbase/pocketbase/models"
+
+	internalErrors "github.com/fragoulis/setip_v2/internal/app/errors"
+)
+
+//nolint:gochecknoglobals
+var paymentHasReceiptErr = validation.NewError("validation_required", "Η είσπραξη έχει ήδη απόξειξη")
+
+type CreateBatchReceiptRequest struct {
+	PaymentIDs []string `json:"payment_ids"`
+	BlockNos   []int    `json:"block_nos"`
+	ReceiptNos []int    `json:"receipt_nos"`
+	IssuedAt   string   `json:"issued_at"`
+	Comments   string   `json:"comments"`
+}
+
+type CreateBatchReceiptResponse struct {
+	IDs []string `json:"ids"`
+}
+
+//nolint:funlen,gocognit,cyclop
+func CreateBatch(
+	ctx echo.Context,
+	app *pocketbase.PocketBase,
+	data *CreateBatchReceiptRequest,
+) (*CreateBatchReceiptResponse, error) {
+	dao, ok := ctx.Get("dao").(*daos.Dao)
+	if !ok {
+		return nil, internalErrors.ErrFailedToGetDao
+	}
+
+	payments := []*models.Record{}
+
+	errs := validation.Errors{}
+	paymentIDErrs := validation.Errors{}
+	receiptNoErrs := validation.Errors{}
+	blockNoErrs := validation.Errors{}
+
+	for i := range data.PaymentIDs {
+		index := fmt.Sprintf("%d", i)
+
+		if data.PaymentIDs[i] == "" {
+			paymentIDErrs[index] = requiredErr
+		}
+
+		// Load the payment.
+		payment, err := dao.FindRecordById("payments", data.PaymentIDs[i])
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				paymentIDErrs[index] = paymentNotFoundErr
+			}
+
+			return nil, fmt.Errorf("failed to find payment: %w", err)
+		}
+
+		if payment.GetString("receipt_id") != "" {
+			paymentIDErrs[index] = paymentHasReceiptErr
+		}
+
+		payments = append(payments, payment)
+
+		if data.ReceiptNos[i] == 0 {
+			receiptNoErrs[index] = requiredErr
+		}
+
+		if data.BlockNos[i] == 0 {
+			blockNoErrs[index] = requiredErr
+		}
+	}
+
+	if data.IssuedAt == "" {
+		errs["issued_at"] = requiredErr
+	}
+
+	if len(errs) != 0 || len(paymentIDErrs) != 0 || len(receiptNoErrs) != 0 || len(blockNoErrs) != 0 {
+		errs["payment_ids"] = paymentIDErrs
+		errs["receipt_nos"] = receiptNoErrs
+		errs["block_nos"] = blockNoErrs
+
+		return nil, errs
+	}
+
+	createdIDs := []string{}
+
+	err := dao.RunInTransaction(func(tx *daos.Dao) error {
+		ctx.Set("dao", tx)
+
+		for i, payment := range payments {
+			request := &CreateReceiptRequest{
+				PaymentID: data.PaymentIDs[i],
+				BlockNo:   data.BlockNos[i],
+				ReceiptNo: data.ReceiptNos[i],
+				IssuedAt:  data.IssuedAt,
+				Comments:  data.Comments,
+			}
+
+			id, err := CreateInternal(ctx, app, tx, payment, request)
+			if err != nil {
+				if validationErrors, ok := err.(validation.Errors); ok {
+					index := fmt.Sprintf("%d", i)
+
+					for field, fieldError := range validationErrors {
+						switch field {
+						case "block_no":
+							blockNoErrs[index] = fieldError
+						case "receipt_no":
+							receiptNoErrs[index] = fieldError
+						}
+					}
+
+					continue
+				}
+
+				return fmt.Errorf("failed to create receipt internal: %w", err)
+			}
+
+			createdIDs = append(createdIDs, id)
+		}
+
+		if len(errs) != 0 || len(receiptNoErrs) != 0 || len(blockNoErrs) != 0 {
+			errs["payment_ids"] = paymentIDErrs
+			errs["receipt_nos"] = receiptNoErrs
+			errs["block_nos"] = blockNoErrs
+
+			return errs
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &CreateBatchReceiptResponse{
+		IDs: createdIDs,
+	}, nil
+}

--- a/internal/app/receipt/service/create_internal.go
+++ b/internal/app/receipt/service/create_internal.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/daos"
+	"github.com/pocketbase/pocketbase/forms"
+	"github.com/pocketbase/pocketbase/models"
+
+	"github.com/fragoulis/setip_v2/internal/events"
+	"github.com/fragoulis/setip_v2/internal/utils"
+)
+
+func CreateInternal(
+	ctx echo.Context,
+	app *pocketbase.PocketBase,
+	dao *daos.Dao,
+	payment *models.Record,
+	data *CreateReceiptRequest,
+) (string, error) {
+
+	collection, err := dao.FindCollectionByNameOrId("receipts")
+	if err != nil {
+		return "", fmt.Errorf("failed to find collection: %w", err)
+	}
+
+	newReceipt := models.NewRecord(collection)
+
+	// Add time to this date.
+	parsedIssuedAt, err := time.Parse(time.DateOnly, data.IssuedAt)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse issue date: %w", err)
+	}
+
+	// Get the current time
+	currentTime := time.Now()
+
+	// Update the parsed time with the current hour, minute, and second
+	issuedAt := time.Date(
+		parsedIssuedAt.Year(),
+		parsedIssuedAt.Month(),
+		parsedIssuedAt.Day(),
+		currentTime.Hour(),
+		currentTime.Minute(),
+		currentTime.Second(),
+		currentTime.Nanosecond(),
+		parsedIssuedAt.Location(),
+	)
+
+	err = dao.RunInTransaction(func(tx *daos.Dao) error {
+		ctx.Set("dao", tx)
+
+		form := forms.NewRecordUpsert(app, newReceipt)
+		form.SetDao(tx)
+
+		newData := map[string]any{
+			"member_id":          payment.GetString("member_id"),
+			"amount_in_euros":    payment.Get("amount_in_euros"),
+			"receipt_no":         data.ReceiptNo,
+			"block_no":           data.BlockNo,
+			"issued_at":          issuedAt,
+			"comments":           data.Comments,
+			"created_by_user_id": utils.CurrentUserID(ctx),
+		}
+
+		err := form.LoadData(newData)
+		if err != nil {
+			return fmt.Errorf("failed to load data: %w", err)
+		}
+
+		//nolint:wrapcheck
+		err = events.WrapCreate(ctx, app, newReceipt, func() error {
+			return form.Submit()
+		})
+		if err != nil {
+			if _, ok := err.(validation.Errors); ok {
+				return err
+			}
+
+			return fmt.Errorf("failed to create receipt: %w", err)
+		}
+
+		return events.WrapUpdate(ctx, app, payment, func() (*models.Record, error) {
+			payment.Set("receipt_id", newReceipt.GetId())
+
+			err := tx.SaveRecord(payment)
+			if err != nil {
+				return nil, fmt.Errorf("failed to update payment with receipt: %w", err)
+			}
+
+			return payment, nil
+		})
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return newReceipt.GetId(), nil
+}

--- a/internal/db/receipt/callbacks.go
+++ b/internal/db/receipt/callbacks.go
@@ -1,0 +1,11 @@
+package payment
+
+import (
+	"github.com/pocketbase/pocketbase"
+
+	"github.com/fragoulis/setip_v2/internal/db/auditlog"
+)
+
+func RegisterCallbacks(app *pocketbase.PocketBase) {
+	auditlog.RegisterCallbacks(app, "receipts")
+}

--- a/main.go
+++ b/main.go
@@ -15,10 +15,12 @@ import (
 	companyAPI "github.com/fragoulis/setip_v2/internal/app/company/api"
 	memberAPI "github.com/fragoulis/setip_v2/internal/app/member/api"
 	paymentAPI "github.com/fragoulis/setip_v2/internal/app/payment/api"
+	receiptAPI "github.com/fragoulis/setip_v2/internal/app/receipt/api"
 	dbCompany "github.com/fragoulis/setip_v2/internal/db/company"
 	dbEmployment "github.com/fragoulis/setip_v2/internal/db/employment"
 	dbMember "github.com/fragoulis/setip_v2/internal/db/member"
 	dbPayment "github.com/fragoulis/setip_v2/internal/db/payment"
+	dbReceipt "github.com/fragoulis/setip_v2/internal/db/receipt"
 	dbSubscription "github.com/fragoulis/setip_v2/internal/db/subscription"
 	_ "github.com/fragoulis/setip_v2/migrations"
 	"github.com/fragoulis/setip_v2/ui"
@@ -33,6 +35,7 @@ func main() {
 		addressAPI.RegisterRoutes(srvEvnt, app)
 		paymentAPI.RegisterRoutes(srvEvnt, app)
 		chaptersAPI.RegisterRoutes(srvEvnt, app)
+		receiptAPI.RegisterRoutes(srvEvnt, app)
 
 		// serves static files from the provided public dir (if exists)
 		srvEvnt.Router.GET("/*", apis.StaticDirectoryHandler(ui.DistDirFS, true))
@@ -46,6 +49,7 @@ func main() {
 	dbEmployment.RegisterCallbacks(app)
 	dbPayment.RegisterCallbacks(app)
 	dbSubscription.RegisterCallbacks(app)
+	dbReceipt.RegisterCallbacks(app)
 
 	app.RootCmd.AddCommand(cmd.NewUserCommand(app))
 	app.RootCmd.AddCommand(cmd.NewSeedCommand(app))

--- a/migrations/1751098138_created_receipts.go
+++ b/migrations/1751098138_created_receipts.go
@@ -1,0 +1,147 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		jsonData := `{
+			"id": "pny9yt9xff7iuf2",
+			"created": "2025-06-28 08:08:58.607Z",
+			"updated": "2025-06-28 08:08:58.607Z",
+			"name": "receipts",
+			"type": "base",
+			"system": false,
+			"schema": [
+				{
+					"system": false,
+					"id": "rf11axda",
+					"name": "member_id",
+					"type": "relation",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"collectionId": "09tdxf99axj2uzj",
+						"cascadeDelete": false,
+						"minSelect": null,
+						"maxSelect": 1,
+						"displayFields": null
+					}
+				},
+				{
+					"system": false,
+					"id": "jvz5o0ej",
+					"name": "amount_in_euros",
+					"type": "number",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"min": null,
+						"max": null,
+						"noDecimal": false
+					}
+				},
+				{
+					"system": false,
+					"id": "eqmm0jyr",
+					"name": "block_no",
+					"type": "text",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"min": null,
+						"max": null,
+						"pattern": ""
+					}
+				},
+				{
+					"system": false,
+					"id": "xamuhaxh",
+					"name": "receipt_no",
+					"type": "text",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"min": null,
+						"max": null,
+						"pattern": ""
+					}
+				},
+				{
+					"system": false,
+					"id": "a1884phk",
+					"name": "issued_at",
+					"type": "date",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"min": "",
+						"max": ""
+					}
+				},
+				{
+					"system": false,
+					"id": "dscazn9i",
+					"name": "comments",
+					"type": "editor",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"convertUrls": false
+					}
+				},
+				{
+					"system": false,
+					"id": "ogedatdf",
+					"name": "created_by_user_id",
+					"type": "relation",
+					"required": false,
+					"presentable": false,
+					"unique": false,
+					"options": {
+						"collectionId": "_pb_users_auth_",
+						"cascadeDelete": false,
+						"minSelect": null,
+						"maxSelect": 1,
+						"displayFields": null
+					}
+				}
+			],
+			"indexes": [],
+			"listRule": null,
+			"viewRule": null,
+			"createRule": null,
+			"updateRule": null,
+			"deleteRule": null,
+			"options": {}
+		}`
+
+		collection := &models.Collection{}
+		if err := json.Unmarshal([]byte(jsonData), &collection); err != nil {
+			return err
+		}
+
+		return daos.New(db).SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db)
+
+		collection, err := dao.FindCollectionByNameOrId("pny9yt9xff7iuf2")
+		if err != nil {
+			return err
+		}
+
+		return dao.DeleteCollection(collection)
+	})
+}

--- a/migrations/1751098500_updated_payments.go
+++ b/migrations/1751098500_updated_payments.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models/schema"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db)
+
+		collection, err := dao.FindCollectionByNameOrId("u6gs4b34n5sryaq")
+		if err != nil {
+			return err
+		}
+
+		// add
+		new_receipt_id := &schema.SchemaField{}
+		if err := json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "iaosck6e",
+			"name": "receipt_id",
+			"type": "relation",
+			"required": false,
+			"presentable": false,
+			"unique": false,
+			"options": {
+				"collectionId": "pny9yt9xff7iuf2",
+				"cascadeDelete": false,
+				"minSelect": null,
+				"maxSelect": 1,
+				"displayFields": null
+			}
+		}`), new_receipt_id); err != nil {
+			return err
+		}
+		collection.Schema.AddField(new_receipt_id)
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db)
+
+		collection, err := dao.FindCollectionByNameOrId("u6gs4b34n5sryaq")
+		if err != nil {
+			return err
+		}
+
+		// remove
+		collection.Schema.RemoveField("iaosck6e")
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/migrations/1751098772_copy_receipt_data_from_payments_to_receipts.go
+++ b/migrations/1751098772_copy_receipt_data_from_payments_to_receipts.go
@@ -1,0 +1,81 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db)
+
+		payments, err := dao.FindRecordsByFilter(
+			"payments",
+			"1=1",
+			"-created",
+			0,
+			0,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to load payments: %w", err)
+		}
+
+		collection, err := dao.FindCollectionByNameOrId("receipts")
+		if err != nil {
+			return fmt.Errorf("failed to find collection: %w", err)
+		}
+
+		err = dao.RunInTransaction(func(tx *daos.Dao) error {
+			for _, payment := range payments {
+				receipt := models.NewRecord(collection)
+
+				receipt.Set("member_id", payment.Get("member_id"))
+				receipt.Set("amount_in_euros", payment.Get("amount_in_euros"))
+				receipt.Set("block_no", payment.Get("receipt_block_no"))
+				receipt.Set("receipt_no", payment.Get("receipt_no"))
+				receipt.Set("issued_at", payment.Get("issued_at"))
+				receipt.Set("comments", payment.Get("comments"))
+				receipt.Set("created_by_user_id", payment.Get("created_by_user_id"))
+
+				err = tx.Save(receipt)
+				if err != nil {
+					return fmt.Errorf("failed to create receipt record: %w", err)
+				}
+
+				payment.Set("receipt_id", receipt.GetId())
+
+				err = tx.Save(payment)
+				if err != nil {
+					return fmt.Errorf("failed to update payment record: %w", err)
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to move receipts: %w", err)
+		}
+
+		return nil
+	}, func(db dbx.Builder) error {
+		_, err := db.
+			NewQuery("UPDATE payments SET receipt_id = NULL").
+			Execute()
+		if err != nil {
+			return fmt.Errorf("failed to empty receipt id in payments: %w", err)
+		}
+
+		_, err = db.
+			NewQuery("DELETE FROM receipts").
+			Execute()
+		if err != nil {
+			return fmt.Errorf("failed to truncate receipts: %w", err)
+		}
+
+		return nil
+	})
+}

--- a/migrations/1751101200_updated_payments.go
+++ b/migrations/1751101200_updated_payments.go
@@ -1,0 +1,91 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models/schema"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("u6gs4b34n5sryaq")
+		if err != nil {
+			return err
+		}
+
+		if err := json.Unmarshal([]byte(`[
+			"CREATE UNIQUE INDEX ` + "`" + `idx_wKn1viw` + "`" + ` ON ` + "`" + `payments` + "`" + ` (` + "`" + `legacy_guid` + "`" + `) WHERE ` + "`" + `legacy_guid` + "`" + ` != ''"
+		]`), &collection.Indexes); err != nil {
+			return err
+		}
+
+		// remove
+		collection.Schema.RemoveField("aokflly3")
+
+		// remove
+		collection.Schema.RemoveField("fjuon9z4")
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("u6gs4b34n5sryaq")
+		if err != nil {
+			return err
+		}
+
+		if err := json.Unmarshal([]byte(`[
+			"CREATE UNIQUE INDEX ` + "`" + `idx_A0oAcq8` + "`" + ` ON ` + "`" + `payments` + "`" + ` (\n  ` + "`" + `receipt_block_no` + "`" + `,\n  ` + "`" + `receipt_no` + "`" + `\n) WHERE ` + "`" + `receipt_block_no` + "`" + ` != '' AND ` + "`" + `receipt_no` + "`" + ` != ''",
+			"CREATE UNIQUE INDEX ` + "`" + `idx_wKn1viw` + "`" + ` ON ` + "`" + `payments` + "`" + ` (` + "`" + `legacy_guid` + "`" + `) WHERE ` + "`" + `legacy_guid` + "`" + ` != ''"
+		]`), &collection.Indexes); err != nil {
+			return err
+		}
+
+		// add
+		del_receipt_block_no := &schema.SchemaField{}
+		if err := json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "aokflly3",
+			"name": "receipt_block_no",
+			"type": "text",
+			"required": false,
+			"presentable": false,
+			"unique": false,
+			"options": {
+				"min": null,
+				"max": null,
+				"pattern": ""
+			}
+		}`), del_receipt_block_no); err != nil {
+			return err
+		}
+		collection.Schema.AddField(del_receipt_block_no)
+
+		// add
+		del_receipt_no := &schema.SchemaField{}
+		if err := json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "fjuon9z4",
+			"name": "receipt_no",
+			"type": "text",
+			"required": false,
+			"presentable": false,
+			"unique": false,
+			"options": {
+				"min": null,
+				"max": null,
+				"pattern": ""
+			}
+		}`), del_receipt_no); err != nil {
+			return err
+		}
+		collection.Schema.AddField(del_receipt_no)
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/migrations/1751101245_updated_receipts.go
+++ b/migrations/1751101245_updated_receipts.go
@@ -1,0 +1,41 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("pny9yt9xff7iuf2")
+		if err != nil {
+			return err
+		}
+
+		if err := json.Unmarshal([]byte(`[
+			"CREATE UNIQUE INDEX ` + "`" + `idx_A0oAcq8` + "`" + ` ON ` + "`" + `payments` + "`" + ` (\n  ` + "`" + `block_no` + "`" + `,\n  ` + "`" + `receipt_no` + "`" + `\n) WHERE ` + "`" + `block_no` + "`" + ` != '' AND ` + "`" + `receipt_no` + "`" + ` != ''"
+		]`), &collection.Indexes); err != nil {
+			return err
+		}
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("pny9yt9xff7iuf2")
+		if err != nil {
+			return err
+		}
+
+		if err := json.Unmarshal([]byte(`[]`), &collection.Indexes); err != nil {
+			return err
+		}
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/migrations/1751110232_updated_receipts.go
+++ b/migrations/1751110232_updated_receipts.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("pny9yt9xff7iuf2")
+		if err != nil {
+			return err
+		}
+
+		collection.ListRule = types.Pointer("@request.auth.id != \"\"")
+
+		collection.ViewRule = types.Pointer("@request.auth.id != \"\"")
+
+		collection.CreateRule = types.Pointer("@request.auth.id != \"\"")
+
+		collection.UpdateRule = types.Pointer("@request.auth.id != \"\"")
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("pny9yt9xff7iuf2")
+		if err != nil {
+			return err
+		}
+
+		collection.ListRule = nil
+
+		collection.ViewRule = nil
+
+		collection.CreateRule = nil
+
+		collection.UpdateRule = nil
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/migrations/1751197957_updated_members.go
+++ b/migrations/1751197957_updated_members.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/daos"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/models/schema"
+)
+
+func init() {
+	m.Register(func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("09tdxf99axj2uzj")
+		if err != nil {
+			return err
+		}
+
+		// add
+		new_fixed_monthly_amount_in_euros := &schema.SchemaField{}
+		if err := json.Unmarshal([]byte(`{
+			"system": false,
+			"id": "7cqmxcai",
+			"name": "fixed_monthly_amount_in_euros",
+			"type": "number",
+			"required": false,
+			"presentable": false,
+			"unique": false,
+			"options": {
+				"min": null,
+				"max": null,
+				"noDecimal": false
+			}
+		}`), new_fixed_monthly_amount_in_euros); err != nil {
+			return err
+		}
+		collection.Schema.AddField(new_fixed_monthly_amount_in_euros)
+
+		return dao.SaveCollection(collection)
+	}, func(db dbx.Builder) error {
+		dao := daos.New(db);
+
+		collection, err := dao.FindCollectionByNameOrId("09tdxf99axj2uzj")
+		if err != nil {
+			return err
+		}
+
+		// remove
+		collection.Schema.RemoveField("7cqmxcai")
+
+		return dao.SaveCollection(collection)
+	})
+}

--- a/ui/src/lib/CreatePaymentTableAction.svelte
+++ b/ui/src/lib/CreatePaymentTableAction.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Drawer, CloseButton } from 'flowbite-svelte';
+	import { UserCircleOutline } from 'flowbite-svelte-icons';
+	import { sineIn } from 'svelte/easing';
+	import PaymentCreateFormForBatchMembers from '$lib/PaymentCreateFormForBatchMembers.svelte';
+	import { sharedToast } from '$lib/store';
+
+	export let hidden = true;
+	export let members: Set<string>;
+
+	let transitionParams = {
+		x: 320,
+		duration: 200,
+		easing: sineIn
+	};
+
+	const onSuccess = () => {
+		$sharedToast.show = true;
+		$sharedToast.success = true;
+		$sharedToast.message = 'Η εισπράξεις περάστηκαν επιτυχώς.';
+
+		hidden = true;
+	};
+
+	const onError = async (e: any) => {
+		$sharedToast.show = true;
+		$sharedToast.success = false;
+		$sharedToast.message = e.detail?.message || e.message;
+	};
+</script>
+
+<Drawer placement="right" transitionType="fly" {transitionParams} bind:hidden width="w-2/3">
+	<div class="flex items-center">
+		<h5
+			id="drawer-label"
+			class="inline-flex items-center mb-4 text-xl font-bold text-gray-800 dark:text-gray-400"
+		>
+			<UserCircleOutline class="w-5 h-5 me-2.5" />Δημιουργία εισπράξεων για τα επιλεγμένα μέλη
+		</h5>
+		<CloseButton on:click={() => (hidden = true)} class="mb-4 dark:text-white" />
+	</div>
+
+	<PaymentCreateFormForBatchMembers bind:members on:success={onSuccess} on:failure={onError} />
+</Drawer>

--- a/ui/src/lib/CreatePaymentTableAction.svelte
+++ b/ui/src/lib/CreatePaymentTableAction.svelte
@@ -6,7 +6,7 @@
 	import { sharedToast } from '$lib/store';
 
 	export let hidden = true;
-	export let members: Set<string>;
+	export let members: Map<string, any>;
 
 	let transitionParams = {
 		x: 320,

--- a/ui/src/lib/CreatePaymentTableAction.svelte
+++ b/ui/src/lib/CreatePaymentTableAction.svelte
@@ -17,7 +17,7 @@
 	const onSuccess = () => {
 		$sharedToast.show = true;
 		$sharedToast.success = true;
-		$sharedToast.message = 'Η εισπράξεις περάστηκαν επιτυχώς.';
+		$sharedToast.message = 'Οι εισπράξεις περάστηκαν επιτυχώς.';
 
 		hidden = true;
 	};

--- a/ui/src/lib/Datatable.svelte
+++ b/ui/src/lib/Datatable.svelte
@@ -14,16 +14,39 @@
 	export let columns: DatatableColumns;
 	export let records: any[] = [];
 	export let loading: boolean = false;
+	export let selectacble: boolean = false;
+	export let selectedRows: Set<string>;
+
+	let selectAll: boolean = false;
 
 	$: headers = Object.keys(columns);
 	$: fields = Object.values(columns);
 
-	let checked: boolean = false;
+	// Hack to reset selected rows when records change.
+	let lastRecords = records;
+	$: if (records !== lastRecords) {
+		lastRecords = records;
+		selectedRows.clear();
+		selectAll = false;
+	}
+
+	const onSelectableChangeState = (e: any) => {
+		if (e.detail.selected) {
+			selectedRows.add(e.detail.id);
+		} else {
+			selectedRows.delete(e.detail.id);
+		}
+	};
 </script>
 
 <Table striped={true} hoverable={true}>
 	<TableHead>
 		<TableHeadCell>#</TableHeadCell>
+		{#if selectacble}
+			<TableHeadCell>
+				<Checkbox bind:checked={selectAll} />
+			</TableHeadCell>
+		{/if}
 		{#each headers as header}
 			<TableHeadCell>{header}</TableHeadCell>
 		{/each}
@@ -43,7 +66,14 @@
 			</TableBodyRow>
 		{:else}
 			{#each records as record, i (i)}
-				<DatatableRow index={i + 1} {record} {fields} {checked} />
+				<DatatableRow
+					index={i + 1}
+					{record}
+					{fields}
+					selected={selectAll}
+					{selectacble}
+					on:change={onSelectableChangeState}
+				/>
 			{:else}
 				@
 			{/each}

--- a/ui/src/lib/Datatable.svelte
+++ b/ui/src/lib/Datatable.svelte
@@ -15,7 +15,7 @@
 	export let records: any[] = [];
 	export let loading: boolean = false;
 	export let selectacble: boolean = false;
-	export let selectedRows: Set<string>;
+	export let selectedRows: Set<string> = new Set<string>();
 
 	let selectAll: boolean = false;
 

--- a/ui/src/lib/Datatable.svelte
+++ b/ui/src/lib/Datatable.svelte
@@ -15,7 +15,7 @@
 	export let records: any[] = [];
 	export let loading: boolean = false;
 	export let selectacble: boolean = false;
-	export let selectedRows: Set<string> = new Set<string>();
+	export let selectedRows: Map<string, any> = new Map<string, any>();
 
 	let selectAll: boolean = false;
 
@@ -32,9 +32,9 @@
 
 	const onSelectableChangeState = (e: any) => {
 		if (e.detail.selected) {
-			selectedRows.add(e.detail.id);
+			selectedRows.set(e.detail.record.id, e.detail.record);
 		} else {
-			selectedRows.delete(e.detail.id);
+			selectedRows.delete(e.detail.record.id);
 		}
 	};
 </script>

--- a/ui/src/lib/DatatableRow.svelte
+++ b/ui/src/lib/DatatableRow.svelte
@@ -1,18 +1,33 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import { TableBodyCell, TableBodyRow, Checkbox } from 'flowbite-svelte';
+
+	const dispatch = createEventDispatcher();
 
 	export let index: number;
 	export let record: any;
 	export let fields: string[];
-	export let checked = false;
+	export let selected = false;
+	export let selectacble = false;
 
-	const selectRow = (e: MouseEvent) => {
-		checked = !checked;
-	};
+	// Hack to trigger the change event when selected is updated.
+	let lastSelected = selected;
+	$: if (selected !== lastSelected) {
+		lastSelected = selected;
+		dispatch('change', {
+			id: record.id,
+			selected: selected
+		});
+	}
 </script>
 
 <TableBodyRow>
 	<TableBodyCell>{index}</TableBodyCell>
+	{#if selectacble}
+		<TableBodyCell>
+			<Checkbox checked={selected} on:change={() => (selected = !selected)} value={record.id} />
+		</TableBodyCell>
+	{/if}
 	{#each fields as field}
 		<TableBodyCell class="break-works whitespace-normal">
 			{#if typeof field === 'function'}

--- a/ui/src/lib/DatatableRow.svelte
+++ b/ui/src/lib/DatatableRow.svelte
@@ -15,7 +15,7 @@
 	$: if (selected !== lastSelected) {
 		lastSelected = selected;
 		dispatch('change', {
-			id: record.id,
+			record: record,
 			selected: selected
 		});
 	}

--- a/ui/src/lib/DatatableSearchForm.svelte
+++ b/ui/src/lib/DatatableSearchForm.svelte
@@ -5,7 +5,7 @@
 	import { Search, Button, Dropdown, Toggle } from 'flowbite-svelte';
 	import pb from '$lib/pocketbase';
 	import { browser } from '$app/environment';
-	import { type DatatableSearchForm, type DatatableColumns } from '$lib/types';
+	import { type DatatableSearchForm } from '$lib/types';
 	import { ChevronDownOutline } from 'flowbite-svelte-icons';
 
 	export let collection: string;
@@ -13,9 +13,11 @@
 	export let loading: boolean = false;
 	export let records: any[] = [];
 	export let searchForm: any = null;
+	export let actions: any = null;
 	export let showExport: boolean = false;
 	export let availableColumns: {};
 	export let selectedColumns: {};
+	export let selectedRows: Set<string>;
 
 	let form: DatatableSearchForm = { active_only: true };
 	let total: number = 0;
@@ -175,6 +177,9 @@
 		<div class="flex items-center space-x-4 justify-between">
 			<div>Αποτελέσματα: {total}</div>
 			<div class="flex items-center space-x-4 justify-between">
+				{#if actions}
+					<svelte:component this={actions} {selectedRows} />
+				{/if}
 				<Button outline pill color="light">Στήλες<ChevronDownOutline /></Button>
 				<Dropdown class="w-56 p-3 space-y-1">
 					{#each Object.keys(availableColumns) as name}

--- a/ui/src/lib/DatatableSearchForm.svelte
+++ b/ui/src/lib/DatatableSearchForm.svelte
@@ -17,9 +17,9 @@
 	export let showExport: boolean = false;
 	export let availableColumns: {};
 	export let selectedColumns: {};
-	export let selectedRows: Set<string>;
+	export let selectedRows: Set<string> = new Set<string>();
 
-	let form: DatatableSearchForm = { active_only: true };
+	let form: DatatableSearchForm = {};
 	let total: number = 0;
 	let requestKey: string = 'datatablesearchform';
 

--- a/ui/src/lib/DatatableSearchForm.svelte
+++ b/ui/src/lib/DatatableSearchForm.svelte
@@ -17,7 +17,7 @@
 	export let showExport: boolean = false;
 	export let availableColumns: {};
 	export let selectedColumns: {};
-	export let selectedRows: Set<string> = new Set<string>();
+	export let selectedRows: Map<string, any> = new Map<string, any>();
 
 	let form: DatatableSearchForm = {};
 	let total: number = 0;

--- a/ui/src/lib/ErrorToast.svelte
+++ b/ui/src/lib/ErrorToast.svelte
@@ -11,7 +11,7 @@
 	position="top-right"
 	color="red"
 	transition={slide}
-	bind:open
+	bind:toastStatus={open}
 	divClass="z-[60] w-full max-w-xs p-4 text-red-500 bg-green-100 shadow dark:text-gray-400 dark:bg-gray-800 gap-3"
 >
 	<svelte:fragment slot="icon">

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -33,9 +33,23 @@
 			}
 
 			if (err.data) {
-				errors = objectMap(err.data.data, (v: any) => {
-					return v.message;
-				});
+				errors = {};
+
+				let errData = err.data.data;
+
+				for (let field in errData) {
+					if ('message' in errData[field]) {
+						// single error
+						errors[field] = errData[field].message;
+					} else {
+						// array of errors
+						errors[field] = [];
+						for (let index in errData[field]) {
+							errors[field][index] = errData[field][index].message;
+						}
+					}
+				}
+
 				const firstErrorId = Object.keys(errors)[0];
 				document.getElementById(firstErrorId)?.focus();
 				dispatch('failure', { message: err.message, errors: errors });

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -19,7 +19,6 @@
 			return;
 		}
 
-		errors = {};
 		saving = true;
 		try {
 			dispatch('beforeSend');

--- a/ui/src/lib/InputField.svelte
+++ b/ui/src/lib/InputField.svelte
@@ -20,11 +20,12 @@
 	export let min: number | undefined = undefined;
 	export let max: number | undefined = undefined;
 	export let help: string = '';
+	export let divClass: string = 'mb-4';
 </script>
 
-<div class="mb-4">
+<div class={divClass}>
 	{#if type == 'textarea'}
-		<Textarea rows="8" placeholder={label} bind:value on:keyup />
+		<Textarea rows={8} placeholder={label} bind:value on:keyup />
 		{#if help != ''}
 			<Helper class="mt-2 text-sm">
 				{help}

--- a/ui/src/lib/IssueDatePaymentsTableColumn.svelte
+++ b/ui/src/lib/IssueDatePaymentsTableColumn.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { A } from 'flowbite-svelte';
+	import { type Payment } from '$lib/types';
+
+	export let record: Payment;
+</script>
+
+<A href={`/admin/payment/edit?id=${record.id}`}>
+	{record.issued_at_formatted}
+</A>

--- a/ui/src/lib/LatestCashierPayments.svelte
+++ b/ui/src/lib/LatestCashierPayments.svelte
@@ -17,9 +17,11 @@
 
 	export const refresh = async () => {
 		try {
-			records = await pb.send('/payments', {
+			const res = await pb.send('/payments', {
 				query: { user_ids: [loggedInUserID()] }
 			});
+
+			records = res.records;
 		} catch (e: any) {
 			console.error(e);
 		}

--- a/ui/src/lib/MemberFormFields.svelte
+++ b/ui/src/lib/MemberFormFields.svelte
@@ -4,7 +4,7 @@
 	import MemberAddressTabbedFormFields from '$lib/MemberAddressTabbedFormFields.svelte';
 	import InputGroup from '$lib/InputGroup.svelte';
 	import MemberCompanyFormFields from '$lib/MemberCompanyFormFields.svelte';
-	import { type UpdateMemberForm } from '$lib/types';
+	import { type UpdateMemberForm, type Member } from '$lib/types';
 
 	export let record: Member = {};
 	export let form: UpdateMemberForm = {};

--- a/ui/src/lib/MemberFormFields.svelte
+++ b/ui/src/lib/MemberFormFields.svelte
@@ -118,6 +118,10 @@
 	<ToggleField bind:checked={form.other_union} label="Μέλος άλλους σωματείου" />
 </div>
 
+<div class="w-full">
+	<ToggleField bind:checked={form.fixed_payment} label="Πληρώνει με πάγια εντολή" />
+</div>
+
 <InputGroup legend="Γενικά σχόλια">
 	<div class="w-full">
 		<InputField id="comments" type="textarea" label="Σχόλια" bind:value={form.comments} />

--- a/ui/src/lib/MemberNamePaymentsTableColumn.svelte
+++ b/ui/src/lib/MemberNamePaymentsTableColumn.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { A } from 'flowbite-svelte';
+	import { type Payment } from '$lib/types';
+
+	export let record: Payment;
+</script>
+
+<A href={`/admin/member?id=${record.member_id}`}>
+	{record.member_name} | {record.member_no}
+</A>

--- a/ui/src/lib/MemberSearchForm.svelte
+++ b/ui/src/lib/MemberSearchForm.svelte
@@ -22,6 +22,7 @@
 		form.address_city_ids = [];
 		form.legacy_area = '';
 		form.chapter_id = '';
+		form.with_fixed_monthly_payment = undefined;
 	};
 </script>
 
@@ -30,6 +31,13 @@
 </div>
 <div class="w-full">
 	<ToggleField name="with_comments" bind:checked={form.with_comments} label="Με σχόλια" />
+</div>
+<div class="w-full">
+	<ToggleField
+		name="with_fixed_monthly_payment"
+		bind:checked={form.with_fixed_monthly_payment}
+		label="Πληρώνουν με πάγια εντολή"
+	/>
 </div>
 
 <div class="w-full grid grid-cols-2 gap-4 px-4 pt-4 bg-gray-100 rounded-lg border">

--- a/ui/src/lib/MemberSearchForm.svelte
+++ b/ui/src/lib/MemberSearchForm.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import ToggleField from '$lib/ToggleField.svelte';
 	import AutocompleteCompanyFormField from '$lib/AutocompleteCompanyFormField.svelte';
-	import { type DatatableSearchForm, type Chapter } from '$lib/types';
+	import { type MemberSearchForm, type Chapter } from '$lib/types';
 	import InputField from '$lib/InputField.svelte';
 	import MultiSelectAsyncFormField from '$lib/MultiSelectAsyncFormField.svelte';
 	import SelectAsyncFormField from './SelectAsyncFormField.svelte';
 	import { Tabs, TabItem } from 'flowbite-svelte';
 
-	export let form: DatatableSearchForm;
+	export let form: MemberSearchForm;
 
 	let companyQuery: string = '';
 	let addressFilterType: 'address' | 'chapter' = 'address';
@@ -24,6 +24,8 @@
 		form.chapter_id = '';
 		form.with_fixed_monthly_payment = undefined;
 	};
+
+	reset();
 </script>
 
 <div class="w-full">

--- a/ui/src/lib/MemberView.svelte
+++ b/ui/src/lib/MemberView.svelte
@@ -47,6 +47,7 @@
 		'Αριθμός Δελτίου Ταυτότητας': (r: Member) => r.id_card_number,
 		'Αριθμός Μητρώου Ασφαλισμένου': (r: Member) => r.social_security_num,
 		'Μέλος άλλου σωματείου': (r: Member) => (r.other_union ? 'Ναι' : 'Όχι'),
+		'Πληρώνει με πάγια εντολή': (r: Member) => (r.fixed_payment ? 'Ναι' : 'Όχι'),
 		Σχόλια: MemberCommentsAutosave
 	};
 

--- a/ui/src/lib/MembersTable.svelte
+++ b/ui/src/lib/MembersTable.svelte
@@ -4,6 +4,7 @@
 	import PaymentStatusTableColumn from '$lib/PaymentStatusTableColumn.svelte';
 	import Datatable from '$lib/Datatable.svelte';
 	import MemberSearchForm from '$lib/MemberSearchForm.svelte';
+	import MembersTableActions from '$lib/MembersTableActions.svelte';
 	import DatatableSearchForm from '$lib/DatatableSearchForm.svelte';
 	import { type DatatableColumns } from '$lib/types';
 
@@ -30,6 +31,7 @@
 		Εταιρεία: MemberCompanyNameTableColumn
 	};
 	let records: any[] = [];
+	let selectedRows: Set<string> = new Set<string>();
 </script>
 
 <div class="my-5">
@@ -40,8 +42,11 @@
 		collection="members"
 		placeholder="Αναζήτηση βάσει ονόματος, αριθμό μητρώου, email, τηλεφώνου"
 		searchForm={MemberSearchForm}
+		actions={MembersTableActions}
+		bind:selectedRows
 		showExport={true}
 	/>
 </div>
 
-<Datatable bind:records bind:columns={selectedColumns}></Datatable>
+<Datatable bind:records bind:columns={selectedColumns} bind:selectedRows selectacble={true}
+></Datatable>

--- a/ui/src/lib/MembersTable.svelte
+++ b/ui/src/lib/MembersTable.svelte
@@ -31,7 +31,7 @@
 		Εταιρεία: MemberCompanyNameTableColumn
 	};
 	let records: any[] = [];
-	let selectedRows: Set<string> = new Set<string>();
+	let selectedRows: Map<string, any> = new Map<string, any>();
 </script>
 
 <div class="my-5">

--- a/ui/src/lib/MembersTableActions.svelte
+++ b/ui/src/lib/MembersTableActions.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { A } from 'flowbite-svelte';
+	import { Dropdown, Button } from 'flowbite-svelte';
+	import { ChevronDownOutline } from 'flowbite-svelte-icons';
+	import CreatePaymentTableAction from '$lib/CreatePaymentTableAction.svelte';
+
+	export let createPaymentActionHidden = true;
+	export let selectedRows: Set<string>;
+</script>
+
+<Button outline pill color="light">Ενέργειες<ChevronDownOutline /></Button>
+<Dropdown class="w-56 p-3 space-y-1">
+	<li>
+		<A
+			on:click={(e) => {
+				e.preventDefault();
+				createPaymentActionHidden = false;
+			}}>Δημιουργία είσπραξης</A
+		>
+	</li>
+</Dropdown>
+
+<CreatePaymentTableAction bind:hidden={createPaymentActionHidden} bind:members={selectedRows} />

--- a/ui/src/lib/MembersTableActions.svelte
+++ b/ui/src/lib/MembersTableActions.svelte
@@ -5,7 +5,7 @@
 	import CreatePaymentTableAction from '$lib/CreatePaymentTableAction.svelte';
 
 	export let createPaymentActionHidden = true;
-	export let selectedRows: Set<string>;
+	export let selectedRows: Map<string, any>;
 </script>
 
 <Button outline pill color="light">Ενέργειες<ChevronDownOutline /></Button>

--- a/ui/src/lib/PaymentCreateForm.svelte
+++ b/ui/src/lib/PaymentCreateForm.svelte
@@ -97,7 +97,13 @@
 							Ημερομηνία: <span class="font-bold">{paymentDetails.issued_at_formatted}</span>
 						</li>
 						<li>
-							Απόδειξη: <span class="font-bold">{paymentDetails.receipt_no}</span>
+							Απόδειξη: <span class="font-bold">
+								{#if paymentDetails.receipt_no > 0}
+									#{paymentDetails.receipt_no} ({paymentDetails.receipt_block_no})
+								{:else}
+									Χωρίς απόδειξη
+								{/if}
+							</span>
 						</li>
 						<li>
 							Ποσό: <span class="font-bold">{paymentDetails.amount} €</span>

--- a/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
+++ b/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { type CreatePaymentFormForBatchMembers } from '$lib/types';
+	import InputField from '$lib/InputField.svelte';
+	import Form from '$lib/Form.svelte';
+	import { activePayment } from '$lib/store';
+	import { todayStr } from '$lib/utils';
+	import InputGroup from '$lib/InputGroup.svelte';
+	import { Input } from 'flowbite-svelte';
+
+	const dispatch = createEventDispatcher();
+
+	export let members: Set<string>;
+
+	let form: CreatePaymentFormForBatchMembers = {
+		member_ids: Array.from(members),
+		amount: 2,
+		issued_at: $activePayment.issued_at == '' ? todayStr() : $activePayment.issued_at,
+		comments: ''
+	};
+
+	let errors: CreatePaymentFormForBatchMembers = {};
+</script>
+
+<Form bind:form url="/payments/batch" bind:errors on:success on:failure>
+	<div class="w-full mb-5">
+		<InputGroup legend="Είσπραξη">
+			<InputField
+				type="number"
+				min={0}
+				max={1000}
+				bind:value={form.amount}
+				bind:error={errors.amount}
+			/>
+		</InputGroup>
+	</div>
+
+	<div class="w-full">
+		<InputField
+			id="issued_at"
+			type="date"
+			label="Ημ/νία Καταχώρισης"
+			bind:value={form.issued_at}
+			bind:error={errors.issued_at}
+		/>
+	</div>
+
+	<InputField type="textarea" label="Σχόλια" bind:value={form.comments} />
+</Form>

--- a/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
+++ b/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import { type CreatePaymentFormForBatchMembers } from '$lib/types';
 	import InputField from '$lib/InputField.svelte';
 	import AlertWarning from '$lib/AlertWarning.svelte';
@@ -7,14 +6,11 @@
 	import { activePayment } from '$lib/store';
 	import { todayStr } from '$lib/utils';
 	import InputGroup from '$lib/InputGroup.svelte';
-	import { Input } from 'flowbite-svelte';
 
-	const dispatch = createEventDispatcher();
-
-	export let members: Set<string>;
+	export let members: Map<string, any>;
 
 	let form: CreatePaymentFormForBatchMembers = {
-		member_ids: Array.from(members),
+		member_ids: [...members.keys()],
 		amount: 2,
 		issued_at: $activePayment.issued_at == '' ? todayStr() : $activePayment.issued_at,
 		comments: ''

--- a/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
+++ b/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
@@ -21,7 +21,13 @@
 
 <Form bind:form url="/payments/batch" bind:errors on:success on:failure>
 	<AlertWarning>
-		Η ενέργεια θα δημιουργήσει εισπράξεις <strong>χωρίς απόδειξη</strong>.
+		Η ενέργεια θα δημιουργήσει εισπράξεις <strong>χωρίς απόδειξη</strong> για τα ακόλουθα μέλη:
+
+		<ul>
+			{#each members.values() as member}
+				<li>{member.name_formatted}</li>
+			{/each}
+		</ul>
 	</AlertWarning>
 
 	<div class="w-full mb-5">

--- a/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
+++ b/ui/src/lib/PaymentCreateFormForBatchMembers.svelte
@@ -2,6 +2,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import { type CreatePaymentFormForBatchMembers } from '$lib/types';
 	import InputField from '$lib/InputField.svelte';
+	import AlertWarning from '$lib/AlertWarning.svelte';
 	import Form from '$lib/Form.svelte';
 	import { activePayment } from '$lib/store';
 	import { todayStr } from '$lib/utils';
@@ -23,6 +24,10 @@
 </script>
 
 <Form bind:form url="/payments/batch" bind:errors on:success on:failure>
+	<AlertWarning>
+		Η ενέργεια θα δημιουργήσει εισπράξεις <strong>χωρίς απόδειξη</strong>.
+	</AlertWarning>
+
 	<div class="w-full mb-5">
 		<InputGroup legend="Είσπραξη">
 			<InputField

--- a/ui/src/lib/PaymentUpdateForm.svelte
+++ b/ui/src/lib/PaymentUpdateForm.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { type Payment, type UpdatePaymentForm } from '$lib/types';
 	import InputField from '$lib/InputField.svelte';
+	import InputGroup from '$lib/InputGroup.svelte';
+	import ToggleField from '$lib/ToggleField.svelte';
 	import Form from '$lib/Form.svelte';
 
 	export let record: Payment;
@@ -9,7 +11,8 @@
 		amount: record.amount,
 		receipt_block_no: record.receipt_block_no,
 		receipt_no: record.receipt_no,
-		comments: record.comments
+		comments: record.comments,
+		without_receipt: record.receipt_id == ''
 	};
 	let errors: UpdatePaymentForm = {};
 </script>
@@ -24,37 +27,45 @@
 			on:success
 			on:failure
 		>
-			<div class="w-full mb-5">
-				<InputField
-					type="number"
-					label="Ποσό €"
-					min={0}
-					max={1000}
-					bind:value={form.amount}
-					bind:error={errors.amount}
-				/>
-			</div>
+			<InputGroup legend="Είσπραξη">
+				<div class="w-full mb-5">
+					<InputField
+						type="number"
+						label="Ποσό €"
+						min={0}
+						max={1000}
+						bind:value={form.amount}
+						bind:error={errors.amount}
+					/>
+				</div>
+			</InputGroup>
 
-			<div class="w-full">
-				<InputField
-					type="number"
-					label="Απόδειξη"
-					bind:value={form.receipt_no}
-					bind:error={errors.receipt_no}
-					min={0}
-					max={50}
-				/>
-			</div>
-			<div class="w-full">
-				<InputField
-					type="number"
-					label="Μπλοκ αποδείξεων"
-					bind:value={form.receipt_block_no}
-					bind:error={errors.receipt_block_no}
-					min={0}
-					max={1000}
-				/>
-			</div>
+			<InputGroup legend="Απόδειξη">
+				<div class="w-full">
+					<ToggleField bind:checked={form.without_receipt} label="Χωρίς απόδειξη" />
+				</div>
+
+				<div class="w-full" class:hidden={form.without_receipt}>
+					<InputField
+						type="number"
+						label="Απόδειξη"
+						bind:value={form.receipt_no}
+						bind:error={errors.receipt_no}
+						min={0}
+						max={50}
+					/>
+				</div>
+				<div class="w-full" class:hidden={form.without_receipt}>
+					<InputField
+						type="number"
+						label="Μπλοκ αποδείξεων"
+						bind:value={form.receipt_block_no}
+						bind:error={errors.receipt_block_no}
+						min={0}
+						max={1000}
+					/>
+				</div>
+			</InputGroup>
 
 			<InputField type="textarea" label="Σχόλια" bind:value={form.comments} />
 		</Form>

--- a/ui/src/lib/PaymentsTable.svelte
+++ b/ui/src/lib/PaymentsTable.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import MemberNamePaymentsTableColumn from '$lib/MemberNamePaymentsTableColumn.svelte';
+	import IssueDatePaymentsTableColumn from '$lib/IssueDatePaymentsTableColumn.svelte';
+	import Datatable from '$lib/Datatable.svelte';
+	import DatatableSearchForm from '$lib/DatatableSearchForm.svelte';
+	import { type DatatableColumns, type Payment } from '$lib/types';
+
+	const availableColumns: DatatableColumns = {
+		'Ημ/νία': IssueDatePaymentsTableColumn,
+		Μέλος: MemberNamePaymentsTableColumn,
+		Ποσό: 'amount',
+		Μπλοκ: 'receipt_block_no',
+		Απόδειξη: 'receipt_no',
+		Μήνες: 'months'
+	};
+	let selectedColumns: {} = {
+		'Ημ/νία': IssueDatePaymentsTableColumn,
+		Μέλος: MemberNamePaymentsTableColumn,
+		Ποσό: 'amount',
+		Μπλοκ: 'receipt_block_no',
+		Απόδειξη: 'receipt_no',
+		Μήνες: 'months'
+	};
+	let records: any[] = [];
+</script>
+
+<div class="my-5">
+	<DatatableSearchForm
+		{availableColumns}
+		bind:selectedColumns
+		bind:records
+		collection="payments"
+		placeholder="Αναζήτηση βάσει μέλους (ονομα, email, αρ. μητρώου, τηλεφωνο), ημερομηνίας (πχ 2024-11-08)"
+	/>
+</div>
+
+<Datatable bind:records bind:columns={selectedColumns}></Datatable>

--- a/ui/src/lib/PaymentsTable.svelte
+++ b/ui/src/lib/PaymentsTable.svelte
@@ -23,7 +23,7 @@
 		Μήνες: 'months'
 	};
 	let records: any[] = [];
-	let selectedRows: Set<string> = new Set<string>();
+	let selectedRows: Map<string, any> = new Map<string, any>();
 </script>
 
 <div class="my-5">

--- a/ui/src/lib/PaymentsTable.svelte
+++ b/ui/src/lib/PaymentsTable.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PaymentSearchForm from '$lib/payment/SearchForm.svelte';
 	import MemberNamePaymentsTableColumn from '$lib/MemberNamePaymentsTableColumn.svelte';
 	import IssueDatePaymentsTableColumn from '$lib/IssueDatePaymentsTableColumn.svelte';
 	import Datatable from '$lib/Datatable.svelte';
@@ -22,6 +23,7 @@
 		Μήνες: 'months'
 	};
 	let records: any[] = [];
+	let selectedRows: Set<string> = new Set<string>();
 </script>
 
 <div class="my-5">
@@ -29,9 +31,12 @@
 		{availableColumns}
 		bind:selectedColumns
 		bind:records
+		bind:selectedRows
+		searchForm={PaymentSearchForm}
 		collection="payments"
-		placeholder="Αναζήτηση βάσει μέλους (ονομα, email, αρ. μητρώου, τηλεφωνο), ημερομηνίας (πχ 2024-11-08)"
+		placeholder="Αναζήτηση βάσει μέλους (ονομα, email, αρ. μητρώου, τηλεφωνο)"
 	/>
 </div>
 
-<Datatable bind:records bind:columns={selectedColumns}></Datatable>
+<Datatable bind:records bind:columns={selectedColumns} bind:selectedRows selectacble={true}
+></Datatable>

--- a/ui/src/lib/PaymentsTable.svelte
+++ b/ui/src/lib/PaymentsTable.svelte
@@ -2,6 +2,7 @@
 	import PaymentSearchForm from '$lib/payment/SearchForm.svelte';
 	import MemberNamePaymentsTableColumn from '$lib/MemberNamePaymentsTableColumn.svelte';
 	import IssueDatePaymentsTableColumn from '$lib/IssueDatePaymentsTableColumn.svelte';
+	import ReceiptPaymentsTableColumn from '$lib/payment/ReceiptPaymentsTableColumn.svelte';
 	import Datatable from '$lib/Datatable.svelte';
 	import DatatableSearchForm from '$lib/DatatableSearchForm.svelte';
 	import { type DatatableColumns, type Payment } from '$lib/types';
@@ -10,16 +11,14 @@
 		'Ημ/νία': IssueDatePaymentsTableColumn,
 		Μέλος: MemberNamePaymentsTableColumn,
 		Ποσό: 'amount',
-		Μπλοκ: 'receipt_block_no',
-		Απόδειξη: 'receipt_no',
+		Απόδειξη: ReceiptPaymentsTableColumn,
 		Μήνες: 'months'
 	};
 	let selectedColumns: {} = {
 		'Ημ/νία': IssueDatePaymentsTableColumn,
 		Μέλος: MemberNamePaymentsTableColumn,
 		Ποσό: 'amount',
-		Μπλοκ: 'receipt_block_no',
-		Απόδειξη: 'receipt_no',
+		Απόδειξη: ReceiptPaymentsTableColumn,
 		Μήνες: 'months'
 	};
 	let records: any[] = [];

--- a/ui/src/lib/PaymentsTable.svelte
+++ b/ui/src/lib/PaymentsTable.svelte
@@ -6,6 +6,7 @@
 	import Datatable from '$lib/Datatable.svelte';
 	import DatatableSearchForm from '$lib/DatatableSearchForm.svelte';
 	import { type DatatableColumns, type Payment } from '$lib/types';
+	import PaymentsTableActions from '$lib/payment/TableActions.svelte';
 
 	const availableColumns: DatatableColumns = {
 		'Ημ/νία': IssueDatePaymentsTableColumn,
@@ -32,6 +33,7 @@
 		bind:records
 		bind:selectedRows
 		searchForm={PaymentSearchForm}
+		actions={PaymentsTableActions}
 		collection="payments"
 		placeholder="Αναζήτηση βάσει μέλους (ονομα, email, αρ. μητρώου, τηλεφωνο)"
 	/>

--- a/ui/src/lib/SideNav.svelte
+++ b/ui/src/lib/SideNav.svelte
@@ -96,6 +96,16 @@
 			</SidebarItem>
 		</SidebarGroup>
 
+		<SidebarGroup>
+			<SidebarItem label="Εισπράξεις" href="/admin/payments">
+				<svelte:fragment slot="icon">
+					<EuroOutline
+						class="w-6 h-6 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white"
+					/>
+				</svelte:fragment>
+			</SidebarItem>
+		</SidebarGroup>
+
 		<SidebarGroup border>
 			<SidebarItem label="Αποσύνδεση" on:click={logOutUser}>
 				<svelte:fragment slot="icon">

--- a/ui/src/lib/SuccessToast.svelte
+++ b/ui/src/lib/SuccessToast.svelte
@@ -11,7 +11,7 @@
 	position="top-right"
 	color="green"
 	transition={slide}
-	bind:open
+	bind:toastStatus={open}
 	divClass="z-[60] w-full max-w-xs p-4 text-gray-500 bg-green-100 shadow dark:text-gray-400 dark:bg-gray-800 gap-3"
 >
 	<svelte:fragment slot="icon">

--- a/ui/src/lib/payment/CreateReceiptTableAction.svelte
+++ b/ui/src/lib/payment/CreateReceiptTableAction.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Drawer, CloseButton } from 'flowbite-svelte';
+	import { UserCircleOutline } from 'flowbite-svelte-icons';
+	import { sineIn } from 'svelte/easing';
+	import ReceiptCreateFormForBatchPayments from '$lib/payment/ReceiptCreateFormForBatchPayments.svelte';
+	import { sharedToast } from '$lib/store';
+
+	export let hidden = true;
+	export let payments: Map<string, any>;
+
+	let transitionParams = {
+		x: 320,
+		duration: 200,
+		easing: sineIn
+	};
+
+	const onSuccess = () => {
+		$sharedToast.show = true;
+		$sharedToast.success = true;
+		$sharedToast.message = 'Οι αποδείξεις δημιουργήθηκαν επιτυχώς.';
+
+		hidden = true;
+	};
+
+	const onError = async (e: any) => {
+		$sharedToast.show = true;
+		$sharedToast.success = false;
+		$sharedToast.message = e.detail?.message || e.message;
+	};
+</script>
+
+<Drawer placement="right" transitionType="fly" {transitionParams} bind:hidden width="w-2/3">
+	<div class="flex items-center">
+		<h5
+			id="drawer-label"
+			class="inline-flex items-center mb-4 text-xl font-bold text-gray-800 dark:text-gray-400"
+		>
+			<UserCircleOutline class="w-5 h-5 me-2.5" />Δημιουργία αποδείξεων για τις επιλεγμένες πληρωμές
+		</h5>
+		<CloseButton on:click={() => (hidden = true)} class="mb-4 dark:text-white" />
+	</div>
+
+	<ReceiptCreateFormForBatchPayments bind:payments on:success={onSuccess} on:failure={onError} />
+</Drawer>

--- a/ui/src/lib/payment/ReceiptCreateFormForBatchPayments.svelte
+++ b/ui/src/lib/payment/ReceiptCreateFormForBatchPayments.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import {
+		Helper,
+		Table,
+		TableBody,
+		TableBodyCell,
+		TableBodyRow,
+		TableHead,
+		TableHeadCell
+	} from 'flowbite-svelte';
+	import { type CreateReceiptFormForBatchPayments } from '$lib/types';
+	import InputField from '$lib/InputField.svelte';
+	import AlertWarning from '$lib/AlertWarning.svelte';
+	import Form from '$lib/Form.svelte';
+	import { todayStr } from '$lib/utils';
+
+	export let payments: Map<string, any>;
+
+	let form: CreateReceiptFormForBatchPayments = {
+		payment_ids: [...payments.keys()],
+		receipt_nos: [],
+		block_nos: [],
+		issued_at: todayStr(),
+		comments: ''
+	};
+
+	for (let i = 0; i < form.payment_ids.length; i++) {
+		form.receipt_nos[i] = 0;
+		form.block_nos[i] = 0;
+	}
+
+	type Errors = {
+		payment_ids: string[];
+		receipt_nos: string[];
+		block_nos: string[];
+		issued_at: string;
+	};
+
+	let errors: Errors = {
+		payment_ids: [],
+		receipt_nos: [],
+		block_nos: []
+	};
+</script>
+
+<Form bind:form url="/receipts/batch" bind:errors on:success on:failure>
+	<AlertWarning>
+		Η ενέργεια θα δημιουργήσει {payments.size} αποδείξεις.
+	</AlertWarning>
+
+	<Table>
+		<TableHead>
+			<TableHeadCell>#</TableHeadCell>
+			<TableHeadCell>Μέλος</TableHeadCell>
+			<TableHeadCell>Ποσό</TableHeadCell>
+			<TableHeadCell>Αριθμός απόδειξης</TableHeadCell>
+			<TableHeadCell>Μπλοκ</TableHeadCell>
+		</TableHead>
+		<TableBody>
+			{#each payments.values() as payment, i}
+				<TableBodyRow>
+					<TableBodyCell
+						tdClass="px-1 py-1 whitespace-nowrap font-medium text-gray-900 dark:text-white"
+						>{i + 1}</TableBodyCell
+					>
+					<TableBodyCell
+						tdClass="px-1 py-1 whitespace-nowrap font-medium text-gray-900 dark:text-white"
+					>
+						{payment.member_name}
+						{#if errors.payment_ids[i]}
+							<Helper class="mt-2 text-sm" color="red">
+								{errors.payment_ids[i]}
+							</Helper>
+						{/if}
+					</TableBodyCell>
+					<TableBodyCell
+						tdClass="px-1 py-1 whitespace-nowrap font-medium text-gray-900 dark:text-white"
+						>{payment.amount}€</TableBodyCell
+					>
+					<TableBodyCell
+						tdClass="px-1 py-1 whitespace-nowrap font-medium text-gray-900 dark:text-white"
+					>
+						<InputField
+							type="number"
+							size="sm"
+							divClass=""
+							bind:value={form.receipt_nos[i]}
+							bind:error={errors.receipt_nos[i]}
+						/>
+					</TableBodyCell>
+					<TableBodyCell
+						tdClass="px-1 py-1 whitespace-nowrap font-medium text-gray-900 dark:text-white"
+					>
+						<InputField
+							type="number"
+							size="sm"
+							divClass=""
+							bind:value={form.block_nos[i]}
+							bind:error={errors.block_nos[i]}
+						/>
+					</TableBodyCell>
+				</TableBodyRow>
+			{/each}
+		</TableBody>
+	</Table>
+
+	<div class="w-full">
+		<InputField
+			type="date"
+			label="Ημ/νία απόδειξης"
+			bind:value={form.issued_at}
+			bind:error={errors.issued_at}
+		/>
+	</div>
+
+	<InputField type="textarea" label="Σχόλια" bind:value={form.comments} />
+</Form>

--- a/ui/src/lib/payment/ReceiptPaymentsTableColumn.svelte
+++ b/ui/src/lib/payment/ReceiptPaymentsTableColumn.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { A } from 'flowbite-svelte';
+	import { type Payment } from '$lib/types';
+
+	export let record: Payment;
+</script>
+
+{#if record.receipt_id == ''}
+	Χωρίς απόδειξη
+{:else}
+	#{record.receipt_no} ({record.receipt_block_no})
+{/if}

--- a/ui/src/lib/payment/SearchForm.svelte
+++ b/ui/src/lib/payment/SearchForm.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { type PaymentSearchForm } from '$lib/types';
+	import InputField from '$lib/InputField.svelte';
+	import { Select, Label } from 'flowbite-svelte';
+	import { todayStr } from '$lib/utils';
+
+	export let form: PaymentSearchForm;
+
+	const receiptStateOptions = [
+		{ value: '', name: '' },
+		{ value: 'with', name: 'Με απόδειξη' },
+		{ value: 'without', name: 'Χωρίς απόδειξη' }
+	];
+
+	export const reset = () => {
+		form.receipt_state = '';
+		form.issue_date_from = '';
+		form.issue_date_to = '';
+	};
+</script>
+
+<div class="w-full grid grid-cols-4 gap-4 p-4 bg-gray-100 rounded-lg border">
+	<div class="mb-4">
+		<Label class="space-y-2" color="gray">
+			<div class="mb-2">Απόδειξη</div>
+
+			<Select items={receiptStateOptions} bind:value={form.receipt_state} />
+		</Label>
+	</div>
+
+	<InputField type="date" label="Ημ/νία έκδοσης (από)" bind:value={form.issue_date_from} />
+	<InputField type="date" label="Ημ/νία έκδοσης (μέχρι)" bind:value={form.issue_date_to} />
+</div>

--- a/ui/src/lib/payment/SearchForm.svelte
+++ b/ui/src/lib/payment/SearchForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { type PaymentSearchForm } from '$lib/types';
 	import InputField from '$lib/InputField.svelte';
-	import { Select, Label } from 'flowbite-svelte';
-	import { todayStr } from '$lib/utils';
+	import { Select, Label, Button } from 'flowbite-svelte';
+	import { todayStr, weekAgoStr, monthAgoStr } from '$lib/utils';
 
 	export let form: PaymentSearchForm;
 
@@ -20,7 +20,7 @@
 </script>
 
 <div class="w-full grid grid-cols-4 gap-4 p-4 bg-gray-100 rounded-lg border">
-	<div class="mb-4">
+	<div>
 		<Label class="space-y-2" color="gray">
 			<div class="mb-2">Απόδειξη</div>
 
@@ -28,6 +28,52 @@
 		</Label>
 	</div>
 
-	<InputField type="date" label="Ημ/νία έκδοσης (από)" bind:value={form.issue_date_from} />
-	<InputField type="date" label="Ημ/νία έκδοσης (μέχρι)" bind:value={form.issue_date_to} />
+	<div>
+		<InputField type="date" label="Ημ/νία έκδοσης (από)" bind:value={form.issue_date_from} />
+		<Button
+			pill={true}
+			size="xs"
+			on:click={() => {
+				form.issue_date_from = monthAgoStr();
+			}}>Μήνα πριν</Button
+		>
+		<Button
+			pill={true}
+			size="xs"
+			on:click={() => {
+				form.issue_date_from = weekAgoStr();
+			}}>Βδομάδα πριν</Button
+		>
+		<Button
+			pill={true}
+			size="xs"
+			on:click={() => {
+				form.issue_date_from = todayStr();
+			}}>Σήμερα</Button
+		>
+	</div>
+	<div>
+		<InputField type="date" label="Ημ/νία έκδοσης (μέχρι)" bind:value={form.issue_date_to} />
+		<Button
+			pill={true}
+			size="xs"
+			on:click={() => {
+				form.issue_date_to = monthAgoStr();
+			}}>Μήνα πριν</Button
+		>
+		<Button
+			pill={true}
+			size="xs"
+			on:click={() => {
+				form.issue_date_to = weekAgoStr();
+			}}>Βδομάδα πριν</Button
+		>
+		<Button
+			pill={true}
+			size="xs"
+			on:click={() => {
+				form.issue_date_to = todayStr();
+			}}>Σήμερα</Button
+		>
+	</div>
 </div>

--- a/ui/src/lib/payment/TableActions.svelte
+++ b/ui/src/lib/payment/TableActions.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { A } from 'flowbite-svelte';
+	import { Dropdown, Button } from 'flowbite-svelte';
+	import { ChevronDownOutline } from 'flowbite-svelte-icons';
+	import CreateReceiptTableAction from '$lib/payment/CreateReceiptTableAction.svelte';
+
+	export let createReceiptActionHidden = true;
+	export let selectedRows: Map<string, any>;
+</script>
+
+<Button outline pill color="light">Ενέργειες<ChevronDownOutline /></Button>
+<Dropdown class="w-56 p-3 space-y-1">
+	<li>
+		<A
+			on:click={(e) => {
+				e.preventDefault();
+				createReceiptActionHidden = false;
+			}}>Δημιουργία απόδειξης</A
+		>
+	</li>
+</Dropdown>
+
+<CreateReceiptTableAction bind:hidden={createReceiptActionHidden} bind:payments={selectedRows} />

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -23,6 +23,7 @@ export type Payment = {
 	months: number;
 	receipt_block_no: number;
 	receipt_no: number;
+	receipt_id: string;
 	created_by_user: User;
 	issued_at: Date;
 	issued_at_formatted: string;
@@ -49,6 +50,7 @@ export type UpdatePaymentForm = {
 	receipt_block_no?: number;
 	receipt_no?: number;
 	comments?: string;
+	without_receipt?: boolean;
 };
 
 export type PaymentDetails = Payment & {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -43,6 +43,14 @@ export type CreatePaymentForm = {
 	issued_at?: string;
 	comments?: string;
 	name?: string;
+	without_receipt?: boolean;
+};
+
+export type CreatePaymentFormForBatchMembers = {
+	member_ids: string[];
+	amount: number;
+	issued_at: string;
+	comments: string;
 };
 
 export type UpdatePaymentForm = {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -200,6 +200,7 @@ export type UpdateMemberForm = {
 	legacy_post_code?: string;
 	education?: string;
 	specialty?: string;
+	fixed_payment?: boolean;
 };
 
 export type MemberSubscriptionForm = {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -223,6 +223,7 @@ export type DatatableSearchForm = {
 	business_type_ids?: string[];
 	with_comments?: boolean;
 	chapter_id?: string;
+	with_fixed_monthly_payment?: boolean;
 };
 
 export type DatatableColumns = {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -222,7 +222,8 @@ export type NewMemberForm = {
 	MemberSubscriptionForm;
 
 export type MethodOptions = 'POST' | 'PATCH' | 'PUT';
-export type DatatableSearchForm = {
+
+export type MemberSearchForm = {
 	q?: string;
 	active_only?: boolean;
 	company_id?: string;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -235,6 +235,12 @@ export type MemberSearchForm = {
 	with_fixed_monthly_payment?: boolean;
 };
 
+export type PaymentSearchForm = {
+	receipt_state?: 'with' | 'without' | '';
+	issue_date_from?: string;
+	issue_date_to?: string;
+};
+
 export type DatatableColumns = {
 	[key: string]: string | object;
 };

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -53,6 +53,14 @@ export type CreatePaymentFormForBatchMembers = {
 	comments: string;
 };
 
+export type CreateReceiptFormForBatchPayments = {
+	payment_ids: string[];
+	receipt_nos: number[];
+	block_nos: number[];
+	issued_at: string;
+	comments: string;
+};
+
 export type UpdatePaymentForm = {
 	amount?: number;
 	receipt_block_no?: number;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -182,6 +182,7 @@ export type Member = {
 	legacy_post_code: string;
 	specialty: string;
 	education: string;
+	fixed_payment: boolean;
 };
 
 export type Address = {

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -42,3 +42,27 @@ export const todayStr = () => {
 		('0' + today.getDate()).slice(-2)
 	);
 };
+
+export const weekAgoStr = () => {
+	const today = new Date();
+	const ago = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
+	return (
+		ago.getFullYear() +
+		'-' +
+		('0' + (ago.getMonth() + 1)).slice(-2) +
+		'-' +
+		('0' + ago.getDate()).slice(-2)
+	);
+};
+
+export const monthAgoStr = () => {
+	const today = new Date();
+	const ago = new Date(today.getFullYear(), today.getMonth() - 1, today.getDate());
+	return (
+		ago.getFullYear() +
+		'-' +
+		('0' + (ago.getMonth() + 1)).slice(-2) +
+		'-' +
+		('0' + ago.getDate()).slice(-2)
+	);
+};

--- a/ui/src/routes/admin/payment/edit/+page.svelte
+++ b/ui/src/routes/admin/payment/edit/+page.svelte
@@ -31,7 +31,7 @@
 		loading = true;
 		pb.cancelAllRequests();
 		try {
-			record = await pb.send<Payment>(`/payments`, { query: { id: id } });
+			record = await pb.send<Payment>(`/payments/${id}`, {});
 		} catch (e: any) {
 			error = e;
 		}

--- a/ui/src/routes/admin/payments/+page.svelte
+++ b/ui/src/routes/admin/payments/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import PaymentsTable from '$lib/PaymentsTable.svelte';
 	import PageHeader from '$lib/PageHeader.svelte';
 	import { Button } from 'flowbite-svelte';
 	import { PlusOutline } from 'flowbite-svelte-icons';
 	import { isAdmin } from '$lib/utils';
-	import Table from '$lib/Table.svelte';
 
 	const headers: string[] = ['Μέλος', 'Ποσό', 'Ημερομηνία', 'Χρήστης'];
 	const fields: string[] = ['member_id', 'amount_in_euros', 'issued_at', 'created_by_user_id'];
@@ -20,4 +20,5 @@
 		{/if}
 	</svelte:fragment>
 </PageHeader>
-<Table {headers} {fields} collection="payments" sortBy="-issued_at" />
+
+<PaymentsTable />

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -24,15 +24,16 @@ const config = {
 		prerender: {
 			entries: [
 				'/admin/companies',
+				'/admin/companies/create',
 				'/admin/company',
 				'/admin/company/edit',
+				'/admin/members/create',
+				'/admin/members/import',
 				'/admin/member',
 				'/admin/assemblies',
 				'/admin/assemblies/create',
-				'/admin/companies/create',
-				'/admin/members/create',
-				'/admin/members/import',
 				'/admin/payments',
+				'/admin/payments/create',
 				'/admin/payment/edit',
 				'/login',
 			]


### PR DESCRIPTION
We want to decouple receipts from payments because we want to record the event of receiving money from the event of creating a receipt.

A receipt can be created for multiple payments.